### PR TITLE
Accept an ITextFormatter in an overload of WriteTo.Console()

### DIFF
--- a/src/Serilog.Sinks.Console/ConsoleLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Console/ConsoleLoggerConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;
+using Serilog.Formatting;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.SystemConsole;
 
@@ -36,6 +37,28 @@ namespace Serilog
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
             if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
+            return Console(sinkConfiguration, formatter, restrictedToMinimumLevel, levelSwitch);
+        }
+
+        /// <summary>
+        /// Writes log events to <see cref="System.Console"/>.
+        /// </summary>
+        /// <param name="sinkConfiguration">Logger sink configuration.</param>
+        /// <param name="formatter">Controls the rendering of log events into text, for example to log JSON. To
+        /// control plain text formatting, use the overload that accepts an output template.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum level for
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
+        /// <returns>Configuration object allowing method chaining.</returns>
+        public static LoggerConfiguration Console(
+            this LoggerSinkConfiguration sinkConfiguration,
+            ITextFormatter formatter,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
+            if (formatter == null) throw new ArgumentNullException(nameof(formatter));
             return sinkConfiguration.Sink(new ConsoleSink(formatter), restrictedToMinimumLevel, levelSwitch);
         }
     }


### PR DESCRIPTION
 Lines up with File() and RollingFile().
