### PR TITLE
Brought output template text color into line with previous literate theme

### DIFF
--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedDisplayValueFormatter.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedDisplayValueFormatter.cs
@@ -49,21 +49,21 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
             var count = 0;
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                 state.Output.Write('[');
 
             var delim = "";
             for (var index = 0; index < sequence.Elements.Count; ++index)
             {
                 if (delim.Length != 0)
-                    using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                         state.Output.Write(delim);
 
                 delim = ", ";
                 Visit(state, sequence.Elements[index]);
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                 state.Output.Write(']');
 
             return count;
@@ -81,14 +81,14 @@ namespace Serilog.Sinks.SystemConsole.Formatting
                 state.Output.Write(' ');
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                 state.Output.Write('{');
 
             var delim = "";
             for (var index = 0; index < structure.Properties.Count; ++index)
             {
                 if (delim.Length != 0)
-                    using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                         state.Output.Write(delim);
 
                 delim = ", ";
@@ -98,13 +98,13 @@ namespace Serilog.Sinks.SystemConsole.Formatting
                 using (ApplyStyle(state.Output, ConsoleThemeStyle.Name, ref count))
                     state.Output.Write(property.Name);
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                     state.Output.Write('=');
 
                 count += Visit(state.Nest(), property.Value);
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                 state.Output.Write('}');
 
             return count;
@@ -114,31 +114,31 @@ namespace Serilog.Sinks.SystemConsole.Formatting
         {
             var count = 0;
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                 state.Output.Write('{');
 
             var delim = "";
             foreach (var element in dictionary.Elements)
             {
                 if (delim.Length != 0)
-                    using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                         state.Output.Write(delim);
 
                 delim = ", ";
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                     state.Output.Write('[');
 
                 using (ApplyStyle(state.Output, ConsoleThemeStyle.String, ref count))
                     count += Visit(state.Nest(), element.Key);
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                     state.Output.Write("]=");
 
                 count += Visit(state.Nest(), element.Value);
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                 state.Output.Write('}');
 
             return count;

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedJsonValueFormatter.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedJsonValueFormatter.cs
@@ -52,21 +52,21 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
             var count = 0;
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                 state.Output.Write('[');
 
             var delim = "";
             for (var index = 0; index < sequence.Elements.Count; ++index)
             {
                 if (delim.Length != 0)
-                    using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                         state.Output.Write(delim);
 
                 delim = ", ";
                 Visit(state, sequence.Elements[index]);
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                 state.Output.Write(']');
 
             return count;
@@ -76,14 +76,14 @@ namespace Serilog.Sinks.SystemConsole.Formatting
         {
             var count = 0;
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                 state.Output.Write('{');
 
             var delim = "";
             for (var index = 0; index < structure.Properties.Count; ++index)
             {
                 if (delim.Length != 0)
-                    using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                         state.Output.Write(delim);
 
                 delim = ", ";
@@ -93,27 +93,27 @@ namespace Serilog.Sinks.SystemConsole.Formatting
                 using (ApplyStyle(state.Output, ConsoleThemeStyle.Name, ref count))
                     JsonValueFormatter.WriteQuotedJsonString(property.Name, state.Output);
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                     state.Output.Write(": ");
 
                 count += Visit(state, property.Value);
             }
             if (structure.TypeTag != null)
             {
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                     state.Output.Write(delim);
 
                 using (ApplyStyle(state.Output, ConsoleThemeStyle.Name, ref count))
                     JsonValueFormatter.WriteQuotedJsonString("$type", state.Output);
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                     state.Output.Write(": ");
 
                 using (ApplyStyle(state.Output, ConsoleThemeStyle.String, ref count))
                     JsonValueFormatter.WriteQuotedJsonString(structure.TypeTag, state.Output);
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                 state.Output.Write('}');
 
             return count;
@@ -123,14 +123,14 @@ namespace Serilog.Sinks.SystemConsole.Formatting
         {
             int count = 0;
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                 state.Output.Write('{');
 
             var delim = "";
             foreach (var element in dictionary.Elements)
             {
                 if (delim.Length != 0)
-                    using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                         state.Output.Write(delim);
 
                 delim = ", ";
@@ -138,13 +138,13 @@ namespace Serilog.Sinks.SystemConsole.Formatting
                 using (ApplyStyle(state.Output, ConsoleThemeStyle.String, ref count))
                     JsonValueFormatter.WriteQuotedJsonString((element.Key.Value ?? "null").ToString(), state.Output);
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                     state.Output.Write(": ");
 
                 count += Visit(state, element.Value);
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.Punctuation, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
                 state.Output.Write('}');
 
             return count;

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/TextTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/TextTokenRenderer.cs
@@ -32,7 +32,7 @@ namespace Serilog.Sinks.SystemConsole.Output
         public override void Render(LogEvent logEvent, TextWriter output)
         {
             var _ = 0;
-            using (_theme.Apply(output, ConsoleThemeStyle.SecondaryText, ref _))
+            using (_theme.Apply(output, ConsoleThemeStyle.TertiaryText, ref _))
                 output.Write(_text);
         }
     }

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/AnsiConsoleThemes.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/AnsiConsoleThemes.cs
@@ -23,7 +23,7 @@ namespace Serilog.Sinks.SystemConsole.Themes
             {
                 [ConsoleThemeStyle.Text] = "\x1b[37;1m",
                 [ConsoleThemeStyle.SecondaryText] = "\x1b[37m",
-                [ConsoleThemeStyle.Punctuation] = "\x1b[30;1m",
+                [ConsoleThemeStyle.TertiaryText] = "\x1b[30;1m",
                 [ConsoleThemeStyle.Invalid] = "\x1b[33;1m",
                 [ConsoleThemeStyle.Null] = "\x1b[34;1m",
                 [ConsoleThemeStyle.Name] = "\x1b[37m",
@@ -44,7 +44,7 @@ namespace Serilog.Sinks.SystemConsole.Themes
             {
                 [ConsoleThemeStyle.Text] = "\x1b[37;1m",
                 [ConsoleThemeStyle.SecondaryText] = "\x1b[37m",
-                [ConsoleThemeStyle.Punctuation] = "\x1b[30;1m",
+                [ConsoleThemeStyle.TertiaryText] = "\x1b[30;1m",
                 [ConsoleThemeStyle.Invalid] = "\x1b[37;1m\x1b[47m",
                 [ConsoleThemeStyle.Null] = "\x1b[1m\x1b[37;1m",
                 [ConsoleThemeStyle.Name] = "\x1b[37m",
@@ -65,7 +65,7 @@ namespace Serilog.Sinks.SystemConsole.Themes
             {
                 [ConsoleThemeStyle.Text] = "\x1b[38;5;0253m",
                 [ConsoleThemeStyle.SecondaryText] = "\x1b[38;5;0246m",
-                [ConsoleThemeStyle.Punctuation] = "\x1b[38;5;0253m",
+                [ConsoleThemeStyle.TertiaryText] = "\x1b[38;5;0253m",
                 [ConsoleThemeStyle.Invalid] = "\x1b[33;1m",
                 [ConsoleThemeStyle.Null] = "\x1b[38;5;0038m",
                 [ConsoleThemeStyle.Name] = "\x1b[38;5;0081m",

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/ConsoleThemeStyle.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/ConsoleThemeStyle.cs
@@ -30,9 +30,10 @@ namespace Serilog.Sinks.SystemConsole.Themes
         SecondaryText,
 
         /// <summary>
-        /// Punctuation used when writing structured data.
+        /// De-emphasized text, for example literal text in output templates and 
+        /// punctuation used when writing structured data.
         /// </summary>
-        Punctuation,
+        TertiaryText,
 
         /// <summary>
         /// Output demonstrating some kind of configuration issue, e.g. an invalid

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/SystemConsoleThemes.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/SystemConsoleThemes.cs
@@ -24,7 +24,7 @@ namespace Serilog.Sinks.SystemConsole.Themes
             {
                 [ConsoleThemeStyle.Text] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.White },
                 [ConsoleThemeStyle.SecondaryText] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.Gray },
-                [ConsoleThemeStyle.Punctuation] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.DarkGray },
+                [ConsoleThemeStyle.TertiaryText] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.DarkGray },
                 [ConsoleThemeStyle.Invalid] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.Yellow },
                 [ConsoleThemeStyle.Null] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.Blue },
                 [ConsoleThemeStyle.Name] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.Gray },
@@ -45,7 +45,7 @@ namespace Serilog.Sinks.SystemConsole.Themes
             {
                 [ConsoleThemeStyle.Text] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.White },
                 [ConsoleThemeStyle.SecondaryText] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.Gray },
-                [ConsoleThemeStyle.Punctuation] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.DarkGray },
+                [ConsoleThemeStyle.TertiaryText] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.DarkGray },
                 [ConsoleThemeStyle.Invalid] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.White, Background = ConsoleColor.DarkGray},
                 [ConsoleThemeStyle.Null] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.White },
                 [ConsoleThemeStyle.Name] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.Gray },


### PR DESCRIPTION
Punctuation in structured data and text embedded in the output template share a color in the current literate console sink (generally, literal text in the output template is punctuation). This brings the new sink back into line with the older one.