### PR TITLE
Code of Conduct, Contributing Guide & templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,25 @@
+**A few questions before you begin:**
+
+> Is this an issue related to the Serilog core project or one of the [sinks](https://github.com/serilog/serilog/wiki/Provided-Sinks) or [community projects](https://github.com/serilog/serilog/wiki/Community-Projects).  This issue list is intended for Serilog core issues. If this issue relates to a sink or related project, please log on the related repository.  Please use [Gitter chat](https://gitter.im/serilog/serilog) and [Stack Overflow](http://stackoverflow.com/questions/tagged/serilog)  for discussions and questons.
+
+
+**Does this issue relate to a new *feature* or an existing *bug*?**
+- [ ] Bug
+- [ ] New Feature
+
+**What version of Serilog Console Sink is affected by this issue?  Please list the related NuGet package.**
+
+**What is the target framework and operating system affected by this issue? Please see [target frameworks](https://docs.microsoft.com/en-us/nuget/schema/target-frameworks) & [net standard matrix](https://docs.microsoft.com/en-us/dotnet/standard/net-standard).**
+
+- [ ] netCore 2.0
+- [ ] netCore 1.0
+- [ ] 4.7
+- [ ] 4.6.x
+- [ ] 4.5.x
+
+**Please describe the current behaviour you are experiencing?**
+
+**Please describe the expected behaviour if the ?**
+
+**If the current behavior is a bug, please provide the steps to reproduce the issue and if possible a minimal demo of the problem**
+*NOTE: A small code sample goes a long way in expediting bug fixes or illustrating an enhancement you are proposing.*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+**What issue does this PR address?**
+*Please any GitHub issues here*
+
+**Does this PR introduce a breaking change?**
+*Please any changes that may cause issues for users, including binary breaking changes*
+
+**Please check if the PR fulfills these requirements**
+- [ ] The commit follows our [guidelines](https://github.com/serilog/serilog/CONTRIBUTING.md)
+- [ ] Unit Tests for the changes have been added (for bug fixes / features)
+
+**Other information**:
+*Please list any other relevant information here*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 *Please any changes that may cause issues for users, including binary breaking changes*
 
 **Please check if the PR fulfills these requirements**
-- [ ] The commit follows our [guidelines](https://github.com/serilog/serilog/CONTRIBUTING.md)
+- [ ] The commit follows our [guidelines](https://github.com/serilog/serilog-sinks-console/blob/dev/CONTRIBUTING.md)
 - [ ] Unit Tests for the changes have been added (for bug fixes / features)
 
 **Other information**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 **What issue does this PR address?**
-*Please any GitHub issues here*
+*Please list any GitHub issues here*
 
 **Does this PR introduce a breaking change?**
-*Please any changes that may cause issues for users, including binary breaking changes*
+*Please list any changes that may cause issues for users, including binary breaking changes*
 
 **Please check if the PR fulfills these requirements**
 - [ ] The commit follows our [guidelines](https://github.com/serilog/serilog-sinks-console/blob/dev/CONTRIBUTING.md)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Please refer to the [Serilog Code of Conduct](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md) which covers all repositories within the Serilog Organisation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to the Serilog Console Sink
+
+First of all thanks for dropping by, feel free to checkout [Serilog core project's contributing page](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md) which contains some key points about the organisation.
+
+## Reporting an issue
+
+Bugs are tracked via [GitHub][issue_list] issues.  Below are some notes to help create a new issue.  The issue template will help you on the way.
+
+* Create an issue via the [issues list][create_issue].
+* List the version of Serilog that is affected
+* List the target framework and operating system
+* If possible, provide a sample that reproduces the issue.
+
+## Requesting a feature/enhancement
+
+Feature as also tracked via [GitHub][issue_list] issues.  Below are some notes to help create an issue.  The issue template will help you on the way
+
+* Create an issue via the [issues list][create_issue].
+* List the version of Serilog that is affected
+* List the target framework and operating system
+* If possible, provide a sample that reproduces the issue.
+
+## Making a PR
+
+* If an issue does not already exist please create one via the issues list.
+* Fork the repository and create a branch with a descriptive name.
+* Attempt to make commits of logical units.
+* When committing, please reference the issue the commit relates to.
+* Run the build and tests.
+    * Windows platforms can use the `build.ps1` script. (This is the script used in AppVeyor builds)
+    * nix/OSX platforms can use the `build.sh` script.  (This is the script used in Travis builds)
+* Create the PR, the PR template will help provide a stub of what information is required including:
+    * The issue this PR addresses
+    * Unit Tests for the changes have been added.
+
+## Questions?
+
+Serilog has an active and helpful community who are happy to help point you in the right direction or work through any issues you might encounter. You can get in touch via:
+
+ * [Stack Overflow](http://stackoverflow.com/questions/tagged/serilog) - this is the best place to start if you have a question
+ * Our [issue tracker](https://github.com/serilog/serilog/issues) here on GitHub
+ * [Gitter chat](https://gitter.im/serilog/serilog)
+ * The [#serilog tag on Twitter](https://twitter.com/search?q=%23serilog)
+
+Finally when contributing please keep in mind our [Code of Conduct][serilog_code_of_conduct].
+
+[serilog]: https://github.com/serilog/serilog
+[sinks]: https://github.com/serilog/serilog/wiki/Provided-Sinks
+[community_projects]: https://github.com/serilog/serilog/wiki/Community-Projects
+[create_issue]: https://github.com/serilog/serilog-sinks-console/issues/new
+[issue_list]: https://github.com/serilog/serilog-sinks-console/issues/
+[serilog_code_of_conduct]: https://github.com/serilog/serilog/blob/dev/CODE_OF_CONDUCT.md

--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ To achieve output identical to version 2 of this sink, specify a formatter and o
 
 This will bypass theming and use Serilog's built-in message template formatting.
 
+### Contributing
+
+Would you like to help make the Serilog console sink even better? We keep a list of issues that are approachable for newcomers under the [up-for-grabs](https://github.com/serilog/serilog-sinks-console/issues?labels=up-for-grabs&state=open) label. Before starting work on a pull request, we suggest commenting on, or raising, an issue on the issue tracker so that we can help and coordinate efforts.  For more details check out our [contributing guide](CONTRIBUTING.md).
+
+When contributing please keep in mind our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+
 ### Detailed build status
 
 Branch  | AppVeyor | Travis


### PR DESCRIPTION
This PR follows the core repo [change](https://github.com/serilog/serilog/pull/1019) to introduce templates and contribution guidelines.

Attempting to redirect to the core project Code of Conduct and contribution guidelines where possible.  Templates should be generic in most aspects and can be applied across repositories.

*Changes*
* Added issue and PR templates along with contrib and code of conduct pages.