### PR TITLE
Update Nuget package license specification

### DIFF
--- a/src/Serilog.Sinks.Console/Serilog.Sinks.Console.csproj
+++ b/src/Serilog.Sinks.Console/Serilog.Sinks.Console.csproj
@@ -13,7 +13,7 @@
     <PackageTags>serilog;console;terminal</PackageTags>
     <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/serilog/serilog-sinks-console</PackageProjectUrl>
-    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/serilog/serilog-sinks-console</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>


### PR DESCRIPTION
`licenseUrl` is now deprecated in favor of `license expression`

**What issue does this PR address?**
https://github.com/serilog/serilog/issues/1265

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog-sinks-console/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)


The generated Nuget package seems to have the proper license information (as seen in Nuget Package Explorer) : 

![image](https://user-images.githubusercontent.com/160544/50703583-ed893400-1054-11e9-8ed0-92e924e4e839.png)

(clicking "View License Terms" opens the page at : https://licenses.nuget.org/Apache-2.0 )
