### PR TITLE
[#56] Expose `ILogEventSink` without exposing `ConsoleSink`

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ To configure the console sink with a different theme and include the `SourceCont
 }
 ```
 
+### Accessing the `ILogEventSink`
+```
+var theme = AnsiConsoleTheme.Code;
+var textFormatter = ConsoleSinkTextFormatFactory.Create()
+                                                .WithOutPutTemplate("[{Timestamp:HH:mm:ss} {Level:u3}] {Message,-30:lj} {Properties:j}{NewLine}{Exception}")
+                                                .With(theme)
+                                                .Build()
+var eventSink = ConsoleSinkFactory.Create()
+                                  .With(theme)
+                                  .With(textFormatter)
+                                  .Build();
+```
+
+
 ### Upgrading from _Serilog.Sinks.Console_ 2.x
 
 To achieve output identical to version 2 of this sink, specify a formatter and output template explicitly:

--- a/src/Serilog.Sinks.Console/ConsoleSinkFactory.cs
+++ b/src/Serilog.Sinks.Console/ConsoleSinkFactory.cs
@@ -1,0 +1,71 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Sinks.SystemConsole;
+using Serilog.Sinks.SystemConsole.Themes;
+
+namespace Serilog
+{
+    /// <summary>
+    /// Factory class to help construct ILogEventSink
+    /// </summary>
+    public class ConsoleSinkFactory
+    {
+        private LogEventLevel? _standardErrorFromLevel;
+        private ITextFormatter _textFormatter;
+        private ConsoleTheme _theme;
+
+        private ConsoleSinkFactory()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the ConsoleSinkFactory
+        /// </summary>
+        /// <returns></returns>
+        public static ConsoleSinkFactory Create() => new ConsoleSinkFactory();
+
+        /// <summary>
+        /// Sets console theme
+        /// </summary>
+        /// <param name="theme"></param>
+        /// <returns></returns>
+        public ConsoleSinkFactory With(ConsoleTheme theme)
+        {
+            _theme = theme;
+            return this;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="textFormatter"></param>
+        /// <returns></returns>
+        public ConsoleSinkFactory With(ITextFormatter textFormatter)
+        {
+            _textFormatter = textFormatter;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the standard error from level
+        /// </summary>
+        /// <param name="standardErrorFromLevel"></param>
+        /// <returns></returns>
+        public ConsoleSinkFactory With(LogEventLevel? standardErrorFromLevel)
+        {
+            _standardErrorFromLevel = standardErrorFromLevel;
+            return this;
+        }
+
+        /// <summary>
+        /// Uses given set parameters to construct an instance of ILogEventSink
+        /// </summary>
+        /// <returns>Implementation of Serilog.ILogEventSink</returns>
+        public ILogEventSink Build()
+        {
+            var appliedTheme = ConsoleThemeSelector.AppliedTheme(_theme);
+            return new ConsoleSink(appliedTheme, _textFormatter, _standardErrorFromLevel);
+        }
+    }
+}

--- a/src/Serilog.Sinks.Console/ConsoleSinkTextFormatFactory.cs
+++ b/src/Serilog.Sinks.Console/ConsoleSinkTextFormatFactory.cs
@@ -1,0 +1,75 @@
+﻿using System;
+
+using Serilog.Formatting;
+using Serilog.Sinks.SystemConsole.Output;
+using Serilog.Sinks.SystemConsole.Themes;
+
+namespace Serilog
+{
+    /// <summary>
+    /// Factory utility to construct OutputTemplateRenderer ITextFormatter
+    /// </summary>
+    public class ConsoleSinkTextFormatFactory
+    {
+        private const string defaultConsoleOutputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}";
+        private IFormatProvider _formatProvider;
+        private string _outputTemplate;
+        private ConsoleTheme _theme;
+
+        private ConsoleSinkTextFormatFactory()
+        {
+        }
+
+        /// <summary>
+        /// Creates new instance of ConsoleSinkTextFormatFactory
+        /// </summary>
+        /// <returns></returns>
+        public static ConsoleSinkTextFormatFactory Create()
+            => new ConsoleSinkTextFormatFactory();
+
+        /// <summary>
+        /// Sets format provider
+        /// </summary>
+        /// <param name="formatProvider"></param>
+        /// <returns></returns>
+        public ConsoleSinkTextFormatFactory With(IFormatProvider formatProvider)
+        {
+            _formatProvider = formatProvider;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the output template format
+        /// </summary>
+        /// <param name="outputTemplate"></param>
+        /// <returns></returns>
+        public ConsoleSinkTextFormatFactory WithOutPutTemplate(string outputTemplate)
+        {
+            _outputTemplate = outputTemplate;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets console theme
+        /// </summary>
+        /// <param name="theme"></param>
+        /// <returns></returns>
+        public ConsoleSinkTextFormatFactory With(ConsoleTheme theme)
+        {
+            _theme = theme;
+            return this;
+        }
+
+        /// <summary>
+        /// Builds an instance of ITextFormatter from OutputTemplateRenderer
+        /// </summary>
+        /// <returns>OutputTemplateRenderer</returns>
+        public ITextFormatter Build()
+        {
+            var outputTemplate = string.IsNullOrWhiteSpace(_outputTemplate) ? defaultConsoleOutputTemplate : _outputTemplate;
+            var appliedTheme = ConsoleThemeSelector.AppliedTheme(_theme);
+
+            return new OutputTemplateRenderer(appliedTheme, outputTemplate, _formatProvider);
+        }
+    }
+}

--- a/src/Serilog.Sinks.Console/ConsoleThemeSelector.cs
+++ b/src/Serilog.Sinks.Console/ConsoleThemeSelector.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+using Serilog.Sinks.SystemConsole.Themes;
+
+namespace Serilog
+{
+    internal static class ConsoleThemeSelector
+    {
+        public static ConsoleTheme AppliedTheme(ConsoleTheme theme)
+            => Console.IsOutputRedirected || Console.IsErrorRedirected
+                ? ConsoleTheme.None
+                : theme ?? SystemConsoleThemes.Literate;
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**
[GitHub issue 56](https://github.com/serilog/serilog-sinks-console/issues/56)

**Does this PR introduce a breaking change?**
This PR allows the consumer to access the `ILogEventSink` through A `ConsoleSinkFactory`. This exposes existing internal functionality without exposing direct access to `ConsoleSink` class
Added an optional commit that changes the implementation of the `ConsoleLoggerConfigurationExtensions` to use the introduced factories.

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/serilog/serilog-sinks-console/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)
