### PR TITLE
add target to netstandard 2.0

### DIFF
--- a/src/Serilog.Sinks.Console/Serilog.Sinks.Console.csproj
+++ b/src/Serilog.Sinks.Console/Serilog.Sinks.Console.csproj
@@ -4,7 +4,7 @@
     <Description>A Serilog sink that writes log events to the console/terminal.</Description>
     <VersionPrefix>3.1.2</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard2.0;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Console</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -20,7 +20,7 @@
     <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Don't reference the full NETStandard.Library -->
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' != 'netstandard2.0' ">true</DisableImplicitFrameworkReferences>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
     <RootNamespace>Serilog</RootNamespace>
@@ -35,7 +35,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="Serilog" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/test/Serilog.Sinks.Console.Tests/Serilog.Sinks.Console.Tests.csproj
+++ b/test/Serilog.Sinks.Console.Tests/Serilog.Sinks.Console.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.SystemConsole.Tests</AssemblyName>
     <PackageId>Serilog.Sinks.Console.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
**What issue does this PR address?**

#60

**Does this PR introduce a breaking change?**

Support of netstandard2.0 in `Serilog` was added in 2.8.0. By this reason, version of `Serilog` was increased from 2.5.0 to 2.8.0.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/serilog/serilog-sinks-console/blob/dev/CONTRIBUTING.md)
- [X] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
`DisableImplicitFrameworkReferences` is not needed anymore. You can find more details about it [here](https://github.com/dotnet/standard/blob/master/docs/faq.md#should-i-reference-the-meta-package-or-should-i-reference-individual-packages).