### PR TITLE
moved code out of critical section that isn't critical

### DIFF
--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/ConsoleSink.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/ConsoleSink.cs
@@ -58,9 +58,10 @@ namespace Serilog.Sinks.SystemConsole
             {
                 var buffer = new StringWriter(new StringBuilder(DefaultWriteBufferCapacity));
                 _formatter.Format(logEvent, buffer);
+                var formattedLogEventText = buffer.ToString();
                 lock (_syncRoot)
                 {
-                    output.Write(buffer.ToString());
+                    output.Write(formattedLogEventText);
                     output.Flush();
                 }
             }


### PR DESCRIPTION
**What issue does this PR address?**
This PR addresses a small inefficiency in the use of a lock.  There was some code inside the lock body that is not critical.  I moved it outside this lock.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/serilog/serilog-sinks-console/blob/dev/CONTRIBUTING.md)
- [NA] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
*Please list any other relevant information here*
