### PR TITLE
Synchronize writes across all instances of ConsoleSink

### DIFF
--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/ConsoleSink.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/ConsoleSink.cs
@@ -28,7 +28,7 @@ namespace Serilog.Sinks.SystemConsole
         readonly LogEventLevel? _standardErrorFromLevel;
         readonly ConsoleTheme _theme;
         readonly ITextFormatter _formatter;
-        readonly object _syncRoot = new object();
+        static readonly object _syncRoot = new object();
 
         const int DefaultWriteBufferCapacity = 256;
 


### PR DESCRIPTION
Currently, each instance of `ConsoleSink` is synchronized so that concurrent output is not interleaved.

Some scenarios, like reinitialization of the logging pipeline, non-singleton loggers, and _Serilog.Sinks.Map_ can result in multiple instances of `ConsoleSink` being constructed, and today these will happily interleave output. (E.g. see https://github.com/serilog/serilog/issues/1350 .)

This PR switches the lock from sink-specific to shared, so that at least all writes through console sinks will be non-interleaved (even if other console output isn't controlled this way).

CC @skomis-mm 