### PR TITLE
Support for all line colouring

### DIFF
--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedDisplayValueFormatter.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedDisplayValueFormatter.cs
@@ -39,7 +39,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
         {
             if (scalar == null)
                 throw new ArgumentNullException(nameof(scalar));
-            return FormatLiteralValue(scalar, state.Output, state.Format);
+            return FormatLiteralValue(scalar, state.Output, state.Format, state.logEventLevel);
         }
 
         protected override int VisitSequenceValue(ThemedValueFormatterState state, SequenceValue sequence)
@@ -49,7 +49,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
             var count = 0;
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                 state.Output.Write('[');
 
             var delim = string.Empty;
@@ -57,7 +57,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
             {
                 if (delim.Length != 0)
                 {
-                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                         state.Output.Write(delim);
                 }
 
@@ -65,7 +65,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
                 Visit(state, sequence.Elements[index]);
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                 state.Output.Write(']');
 
             return count;
@@ -77,13 +77,13 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
             if (structure.TypeTag != null)
             {
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.Name, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.Name, ref count, state.logEventLevel))
                     state.Output.Write(structure.TypeTag);
 
                 state.Output.Write(' ');
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                 state.Output.Write('{');
 
             var delim = string.Empty;
@@ -91,7 +91,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
             {
                 if (delim.Length != 0)
                 {
-                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                         state.Output.Write(delim);
                 }
 
@@ -99,16 +99,16 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
                 var property = structure.Properties[index];
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.Name, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.Name, ref count, state.logEventLevel))
                     state.Output.Write(property.Name);
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                     state.Output.Write('=');
 
                 count += Visit(state.Nest(), property.Value);
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                 state.Output.Write('}');
 
             return count;
@@ -118,7 +118,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
         {
             var count = 0;
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                 state.Output.Write('{');
 
             var delim = string.Empty;
@@ -126,45 +126,45 @@ namespace Serilog.Sinks.SystemConsole.Formatting
             {
                 if (delim.Length != 0)
                 {
-                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                         state.Output.Write(delim);
                 }
 
                 delim = ", ";
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                     state.Output.Write('[');
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.String, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.String, ref count, state.logEventLevel))
                     count += Visit(state.Nest(), element.Key);
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                     state.Output.Write("]=");
 
                 count += Visit(state.Nest(), element.Value);
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                 state.Output.Write('}');
 
             return count;
         }
 
-        public int FormatLiteralValue(ScalarValue scalar, TextWriter output, string format)
+        public int FormatLiteralValue(ScalarValue scalar, TextWriter output, string format, LogEventLevel logEventLevel)
         {
             var value = scalar.Value;
             var count = 0;
 
             if (value == null)
             {
-                using (ApplyStyle(output, ConsoleThemeStyle.Null, ref count))
+                using (ApplyStyle(output, ConsoleThemeStyle.Null, ref count, logEventLevel))
                     output.Write("null");
                 return count;
             }
 
             if (value is string str)
             {
-                using (ApplyStyle(output, ConsoleThemeStyle.String, ref count))
+                using (ApplyStyle(output, ConsoleThemeStyle.String, ref count, logEventLevel))
                 {
                     if (format != "l")
                         JsonValueFormatter.WriteQuotedJsonString(str, output);
@@ -180,14 +180,14 @@ namespace Serilog.Sinks.SystemConsole.Formatting
                     value is decimal || value is byte || value is sbyte || value is short ||
                     value is ushort || value is float || value is double)
                 {
-                    using (ApplyStyle(output, ConsoleThemeStyle.Number, ref count))
+                    using (ApplyStyle(output, ConsoleThemeStyle.Number, ref count, logEventLevel))
                         scalar.Render(output, format, _formatProvider);
                     return count;
                 }
 
                 if (value is bool b)
                 {
-                    using (ApplyStyle(output, ConsoleThemeStyle.Boolean, ref count))
+                    using (ApplyStyle(output, ConsoleThemeStyle.Boolean, ref count, logEventLevel))
                         output.Write(b);
 
                     return count;
@@ -195,7 +195,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
                 if (value is char ch)
                 {
-                    using (ApplyStyle(output, ConsoleThemeStyle.Scalar, ref count))
+                    using (ApplyStyle(output, ConsoleThemeStyle.Scalar, ref count, logEventLevel))
                     {
                         output.Write('\'');
                         output.Write(ch);
@@ -205,7 +205,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
                 }
             }
 
-            using (ApplyStyle(output, ConsoleThemeStyle.Scalar, ref count))
+            using (ApplyStyle(output, ConsoleThemeStyle.Scalar, ref count, logEventLevel))
                 scalar.Render(output, format, _formatProvider);
 
             return count;

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedJsonValueFormatter.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedJsonValueFormatter.cs
@@ -45,9 +45,9 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
             // At the top level, for scalar values, use "display" rendering.
             if (state.IsTopLevel)
-                return _displayFormatter.FormatLiteralValue(scalar, state.Output, state.Format);
+                return _displayFormatter.FormatLiteralValue(scalar, state.Output, state.Format, state.logEventLevel);
 
-            return FormatLiteralValue(scalar, state.Output);
+            return FormatLiteralValue(scalar, state.Output, state.logEventLevel);
         }
 
         protected override int VisitSequenceValue(ThemedValueFormatterState state, SequenceValue sequence)
@@ -57,7 +57,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
             var count = 0;
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                 state.Output.Write('[');
 
             var delim = string.Empty;
@@ -65,7 +65,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
             {
                 if (delim.Length != 0)
                 {
-                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                         state.Output.Write(delim);
                 }
 
@@ -73,7 +73,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
                 Visit(state.Nest(), sequence.Elements[index]);
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                 state.Output.Write(']');
 
             return count;
@@ -83,7 +83,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
         {
             var count = 0;
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                 state.Output.Write('{');
 
             var delim = string.Empty;
@@ -91,7 +91,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
             {
                 if (delim.Length != 0)
                 {
-                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                         state.Output.Write(delim);
                 }
 
@@ -99,10 +99,10 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
                 var property = structure.Properties[index];
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.Name, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.Name, ref count, state.logEventLevel))
                     JsonValueFormatter.WriteQuotedJsonString(property.Name, state.Output);
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                     state.Output.Write(": ");
 
                 count += Visit(state.Nest(), property.Value);
@@ -110,20 +110,20 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
             if (structure.TypeTag != null)
             {
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                     state.Output.Write(delim);
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.Name, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.Name, ref count, state.logEventLevel))
                     JsonValueFormatter.WriteQuotedJsonString("$type", state.Output);
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                     state.Output.Write(": ");
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.String, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.String, ref count, state.logEventLevel))
                     JsonValueFormatter.WriteQuotedJsonString(structure.TypeTag, state.Output);
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                 state.Output.Write('}');
 
             return count;
@@ -133,7 +133,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
         {
             var count = 0;
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                 state.Output.Write('{');
 
             var delim = string.Empty;
@@ -141,7 +141,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
             {
                 if (delim.Length != 0)
                 {
-                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+                    using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                         state.Output.Write(delim);
                 }
 
@@ -153,36 +153,36 @@ namespace Serilog.Sinks.SystemConsole.Formatting
                         ? ConsoleThemeStyle.String
                         : ConsoleThemeStyle.Scalar;
 
-                using (ApplyStyle(state.Output, style, ref count))
+                using (ApplyStyle(state.Output, style, ref count, state.logEventLevel))
                     JsonValueFormatter.WriteQuotedJsonString((element.Key.Value ?? "null").ToString(), state.Output);
 
-                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+                using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                     state.Output.Write(": ");
 
                 count += Visit(state.Nest(), element.Value);
             }
 
-            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count))
+            using (ApplyStyle(state.Output, ConsoleThemeStyle.TertiaryText, ref count, state.logEventLevel))
                 state.Output.Write('}');
 
             return count;
         }
 
-        int FormatLiteralValue(ScalarValue scalar, TextWriter output)
+        int FormatLiteralValue(ScalarValue scalar, TextWriter output, LogEventLevel logEventLevel)
         {
             var value = scalar.Value;
             var count = 0;
 
             if (value == null)
             {
-                using (ApplyStyle(output, ConsoleThemeStyle.Null, ref count))
+                using (ApplyStyle(output, ConsoleThemeStyle.Null, ref count, logEventLevel))
                     output.Write("null");
                 return count;
             }
 
             if (value is string str)
             {
-                using (ApplyStyle(output, ConsoleThemeStyle.String, ref count))
+                using (ApplyStyle(output, ConsoleThemeStyle.String, ref count, logEventLevel))
                     JsonValueFormatter.WriteQuotedJsonString(str, output);
                 return count;
             }
@@ -191,14 +191,14 @@ namespace Serilog.Sinks.SystemConsole.Formatting
             {
                 if (value is int || value is uint || value is long || value is ulong || value is decimal || value is byte || value is sbyte || value is short || value is ushort)
                 {
-                    using (ApplyStyle(output, ConsoleThemeStyle.Number, ref count))
+                    using (ApplyStyle(output, ConsoleThemeStyle.Number, ref count, logEventLevel))
                         output.Write(((IFormattable)value).ToString(null, CultureInfo.InvariantCulture));
                     return count;
                 }
 
                 if (value is double d)
                 {
-                    using (ApplyStyle(output, ConsoleThemeStyle.Number, ref count))
+                    using (ApplyStyle(output, ConsoleThemeStyle.Number, ref count, logEventLevel))
                     {
                         if (double.IsNaN(d) || double.IsInfinity(d))
                             JsonValueFormatter.WriteQuotedJsonString(d.ToString(CultureInfo.InvariantCulture), output);
@@ -210,7 +210,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
                 if (value is float f)
                 {
-                    using (ApplyStyle(output, ConsoleThemeStyle.Number, ref count))
+                    using (ApplyStyle(output, ConsoleThemeStyle.Number, ref count, logEventLevel))
                     {
                         if (double.IsNaN(f) || double.IsInfinity(f))
                             JsonValueFormatter.WriteQuotedJsonString(f.ToString(CultureInfo.InvariantCulture), output);
@@ -222,7 +222,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
                 if (value is bool b)
                 {
-                    using (ApplyStyle(output, ConsoleThemeStyle.Boolean, ref count))
+                    using (ApplyStyle(output, ConsoleThemeStyle.Boolean, ref count, logEventLevel))
                         output.Write(b ? "true" : "false");
 
                     return count;
@@ -230,14 +230,14 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
                 if (value is char ch)
                 {
-                    using (ApplyStyle(output, ConsoleThemeStyle.Scalar, ref count))
+                    using (ApplyStyle(output, ConsoleThemeStyle.Scalar, ref count, logEventLevel))
                         JsonValueFormatter.WriteQuotedJsonString(ch.ToString(), output);
                     return count;
                 }
 
                 if (value is DateTime || value is DateTimeOffset)
                 {
-                    using (ApplyStyle(output, ConsoleThemeStyle.Scalar, ref count))
+                    using (ApplyStyle(output, ConsoleThemeStyle.Scalar, ref count, logEventLevel))
                     {
                         output.Write('"');
                         output.Write(((IFormattable)value).ToString("O", CultureInfo.InvariantCulture));
@@ -247,7 +247,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
                 }
             }
 
-            using (ApplyStyle(output, ConsoleThemeStyle.Scalar, ref count))
+            using (ApplyStyle(output, ConsoleThemeStyle.Scalar, ref count, logEventLevel))
                 JsonValueFormatter.WriteQuotedJsonString(value.ToString(), output);
 
             return count;

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedValueFormatter.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedValueFormatter.cs
@@ -29,12 +29,12 @@ namespace Serilog.Sinks.SystemConsole.Formatting
             _theme = theme ?? throw new ArgumentNullException(nameof(theme));
         }
 
-        protected StyleReset ApplyStyle(TextWriter output, ConsoleThemeStyle style, ref int invisibleCharacterCount)
+        protected StyleReset ApplyStyle(TextWriter output, ConsoleThemeStyle style, ref int invisibleCharacterCount, LogEventLevel logEventLevel)
         {
-            return _theme.Apply(output, style, ref invisibleCharacterCount);
+            return _theme.Apply(output, style, ref invisibleCharacterCount, logEventLevel);
         }
 
-        public int Format(LogEventPropertyValue value, TextWriter output, string format, bool literalTopLevel = false)
+        public int Format(LogEventPropertyValue value, TextWriter output, string format, LogEventLevel logEventLevel, bool literalTopLevel = false)
         {
             return Visit(new ThemedValueFormatterState { Output = output, Format = format, IsTopLevel = literalTopLevel }, value);
         }

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedValueFormatterState.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedValueFormatterState.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Serilog.Events;
 using System.IO;
 
 namespace Serilog.Sinks.SystemConsole.Formatting
@@ -21,7 +22,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
         public TextWriter Output;
         public string Format;
         public bool IsTopLevel;
-
-        public ThemedValueFormatterState Nest() => new ThemedValueFormatterState { Output = Output };
+        public LogEventLevel logEventLevel;
+        public ThemedValueFormatterState Nest() => new ThemedValueFormatterState { Output = Output, logEventLevel = logEventLevel };
     }
 }

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/EventPropertyTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/EventPropertyTokenRenderer.cs
@@ -44,7 +44,7 @@ namespace Serilog.Sinks.SystemConsole.Output
             }
 
             var _ = 0;
-            using (_theme.Apply(output, ConsoleThemeStyle.SecondaryText, ref _))
+            using (_theme.Apply(output, ConsoleThemeStyle.SecondaryText, ref _, logEvent.Level))
             {
                 var writer = _token.Alignment.HasValue ? new StringWriter() : output;
 

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/ExceptionTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/ExceptionTokenRenderer.cs
@@ -43,7 +43,7 @@ namespace Serilog.Sinks.SystemConsole.Output
             {
                 var style = nextLine.StartsWith(StackFrameLinePrefix) ? ConsoleThemeStyle.SecondaryText : ConsoleThemeStyle.Text;
                 var _ = 0;
-                using (_theme.Apply(output, style, ref _))
+                using (_theme.Apply(output, style, ref _, logEvent.Level))
                     output.WriteLine(nextLine);
             }
         }

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/LevelTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/LevelTokenRenderer.cs
@@ -53,7 +53,7 @@ namespace Serilog.Sinks.SystemConsole.Output
                 levelStyle = ConsoleThemeStyle.Invalid;
 
             var _ = 0;
-            using (_theme.Apply(output, levelStyle, ref _))
+            using (_theme.Apply(output, levelStyle, ref _, logEvent.Level))
                 Padding.Apply(output, moniker, _levelToken.Alignment);
         }
     }

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/MessageTemplateOutputTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/MessageTemplateOutputTokenRenderer.cs
@@ -56,12 +56,12 @@ namespace Serilog.Sinks.SystemConsole.Output
         {
             if (_token.Alignment == null || !_theme.CanBuffer)
             {
-                _renderer.Render(logEvent.MessageTemplate, logEvent.Properties, output);
+                _renderer.Render(logEvent.MessageTemplate, logEvent.Properties, output, logEvent.Level);
                 return;
             }
 
             var buffer = new StringWriter();
-            var invisible = _renderer.Render(logEvent.MessageTemplate, logEvent.Properties, buffer);
+            var invisible = _renderer.Render(logEvent.MessageTemplate, logEvent.Properties, buffer, logEvent.Level);
             var value = buffer.ToString();
             Padding.Apply(output, value, _token.Alignment.Value.Widen(invisible));
         }

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/PropertiesTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/PropertiesTokenRenderer.cs
@@ -63,12 +63,12 @@ namespace Serilog.Sinks.SystemConsole.Output
 
             if (_token.Alignment == null || !_theme.CanBuffer)
             {
-                _valueFormatter.Format(value, output, null);
+                _valueFormatter.Format(value, output, null, logEvent.Level);
                 return;
             }
 
             var buffer = new StringWriter(new StringBuilder(value.Properties.Count * 16));
-            var invisible = _valueFormatter.Format(value, buffer, null);
+            var invisible = _valueFormatter.Format(value, buffer, null, logEvent.Level);
             var str = buffer.ToString();
             Padding.Apply(output, str, _token.Alignment.Value.Widen(invisible));
         }

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/TextTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/TextTokenRenderer.cs
@@ -32,7 +32,7 @@ namespace Serilog.Sinks.SystemConsole.Output
         public override void Render(LogEvent logEvent, TextWriter output)
         {
             var _ = 0;
-            using (_theme.Apply(output, ConsoleThemeStyle.TertiaryText, ref _))
+            using (_theme.Apply(output, ConsoleThemeStyle.TertiaryText, ref _, logEvent.Level))
                 output.Write(_text);
         }
     }

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/TimestampTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/TimestampTokenRenderer.cs
@@ -41,7 +41,7 @@ namespace Serilog.Sinks.SystemConsole.Output
             var sv = new ScalarValue(logEvent.Timestamp);
 
             var _ = 0;
-            using (_theme.Apply(output, ConsoleThemeStyle.SecondaryText, ref _))
+            using (_theme.Apply(output, ConsoleThemeStyle.SecondaryText, ref _, logEvent.Level))
             {
                 if (_token.Alignment == null)
                 {

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/AnsiConsoleTheme.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/AnsiConsoleTheme.cs
@@ -60,8 +60,14 @@ namespace Serilog.Sinks.SystemConsole.Themes
         protected override int ResetCharCount { get; } = AnsiStyleReset.Length;
 
         /// <inheritdoc/>
-        public override int Set(TextWriter output, ConsoleThemeStyle style)
+        public override int Set(TextWriter output, ConsoleThemeStyle style, ConsoleThemeStyle levelLineStyle)
         {
+            if (_styles.TryGetValue(levelLineStyle, out var ansiLineStyle))
+            {
+                output.Write(ansiLineStyle);
+                return ansiLineStyle.Length;
+            }
+
             if (_styles.TryGetValue(style, out var ansiStyle))
             {
                 output.Write(ansiStyle);

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/ConsoleThemeStyle.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/ConsoleThemeStyle.cs
@@ -110,5 +110,35 @@ namespace Serilog.Sinks.SystemConsole.Themes
         /// Level indicator.
         /// </summary>
         LevelFatal,
+
+        /// <summary>
+        /// Level indicator.
+        /// </summary>
+        LevelVerboseLine,
+
+        /// <summary>
+        /// Level indicator.
+        /// </summary>
+        LevelDebugLine,
+
+        /// <summary>
+        /// Level indicator.
+        /// </summary>
+        LevelInformationLine,
+
+        /// <summary>
+        /// Level indicator.
+        /// </summary>
+        LevelWarningLine,
+
+        /// <summary>
+        /// Level indicator.
+        /// </summary>
+        LevelErrorLine,
+
+        /// <summary>
+        /// Level indicator.
+        /// </summary>
+        LevelFatalLine,
     }
 }

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/EmptyConsoleTheme.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/EmptyConsoleTheme.cs
@@ -22,7 +22,7 @@ namespace Serilog.Sinks.SystemConsole.Themes
 
         protected override int ResetCharCount { get; }
 
-        public override int Set(TextWriter output, ConsoleThemeStyle style) => 0;
+        public override int Set(TextWriter output, ConsoleThemeStyle style, ConsoleThemeStyle levelLineStyle) => 0;
 
         public override void Reset(TextWriter output)
         {

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/SystemConsoleTheme.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/SystemConsoleTheme.cs
@@ -60,8 +60,16 @@ namespace Serilog.Sinks.SystemConsole.Themes
         protected override int ResetCharCount { get; }
 
         /// <inheritdoc/>
-        public override int Set(TextWriter output, ConsoleThemeStyle style)
+        public override int Set(TextWriter output, ConsoleThemeStyle style, ConsoleThemeStyle levelLineStyle)
         {
+            if (Styles.TryGetValue(levelLineStyle, out var wctls))
+            {
+                if (wctls.Foreground.HasValue)
+                    Console.ForegroundColor = wctls.Foreground.Value;
+                if (wctls.Background.HasValue)
+                    Console.BackgroundColor = wctls.Background.Value;
+            }
+
             if (Styles.TryGetValue(style, out var wcts))
             {
                 if (wcts.Foreground.HasValue)

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/SystemConsoleThemes.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/SystemConsoleThemes.cs
@@ -38,6 +38,13 @@ namespace Serilog.Sinks.SystemConsole.Themes
                 [ConsoleThemeStyle.LevelWarning] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.Yellow },
                 [ConsoleThemeStyle.LevelError] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.White, Background = ConsoleColor.Red },
                 [ConsoleThemeStyle.LevelFatal] = new SystemConsoleThemeStyle { Foreground = ConsoleColor.White, Background = ConsoleColor.Red },
+                [ConsoleThemeStyle.LevelVerboseLine] = new SystemConsoleThemeStyle { Background = ConsoleColor.DarkBlue },
+                [ConsoleThemeStyle.LevelDebugLine] = new SystemConsoleThemeStyle { Background = ConsoleColor.DarkGray },
+                [ConsoleThemeStyle.LevelInformationLine] = new SystemConsoleThemeStyle { },
+                [ConsoleThemeStyle.LevelWarningLine] = new SystemConsoleThemeStyle { Background = ConsoleColor.DarkYellow },
+                [ConsoleThemeStyle.LevelErrorLine] = new SystemConsoleThemeStyle { Background = ConsoleColor.DarkRed },
+                [ConsoleThemeStyle.LevelFatalLine] = new SystemConsoleThemeStyle { Background = ConsoleColor.Red },
+
             });
 
         public static SystemConsoleTheme Grayscale { get; } = new SystemConsoleTheme(

--- a/test/Serilog.Sinks.Console.Tests/Formatting/ThemedDisplayValueFormatterTests.cs
+++ b/test/Serilog.Sinks.Console.Tests/Formatting/ThemedDisplayValueFormatterTests.cs
@@ -15,7 +15,7 @@ namespace Serilog.Sinks.Console.Tests.Formatting
         {
             var formatter = new ThemedDisplayValueFormatter(ConsoleTheme.None, null);
             var sw = new StringWriter();
-            formatter.FormatLiteralValue(new ScalarValue(value), sw, format);
+            formatter.FormatLiteralValue(new ScalarValue(value), sw, format, LogEventLevel.Information);
             var actual = sw.ToString();
             Assert.Equal(expected, actual);
         }

--- a/test/Serilog.Sinks.Console.Tests/Formatting/ThemedJsonValueFormatterTests.cs
+++ b/test/Serilog.Sinks.Console.Tests/Formatting/ThemedJsonValueFormatterTests.cs
@@ -20,7 +20,7 @@ namespace Serilog.Sinks.Console.Tests.Formatting
             public string Format(object literal)
             {
                 var output = new StringWriter();
-                Format(new SequenceValue(new[] { new ScalarValue(literal) }), output, null);
+                Format(new SequenceValue(new[] { new ScalarValue(literal) }), output, null, LogEventLevel.Information);
                 var o = output.ToString();
                 return o.Substring(1, o.Length - 2);
             }
@@ -85,7 +85,7 @@ namespace Serilog.Sinks.Console.Tests.Formatting
         {
             var formatter = new TestThemedJsonValueFormatter();
             var output = new StringWriter();
-            formatter.Format(value, output, null);
+            formatter.Format(value, output, null, LogEventLevel.Information);
             return output.ToString();
         }
 

--- a/test/Serilog.Sinks.Console.Tests/Rendering/ThemedMessageTemplateRendererTests.cs
+++ b/test/Serilog.Sinks.Console.Tests/Rendering/ThemedMessageTemplateRendererTests.cs
@@ -129,7 +129,7 @@ namespace Serilog.Sinks.Console.Tests.Rendering
             var writer = new StringWriter(output);
             var renderer = new ThemedMessageTemplateRenderer(ConsoleTheme.None,
                 new ThemedDisplayValueFormatter(ConsoleTheme.None, formatProvider), false);
-            renderer.Render(mt, props.ToDictionary(p => p.Name, p => p.Value), writer);
+            renderer.Render(mt, props.ToDictionary(p => p.Name, p => p.Value), writer, Events.LogEventLevel.Information);
             writer.Flush();
             return output.ToString();
         }

--- a/test/Serilog.Sinks.Console.Tests/Support/TracingConsoleTheme.cs
+++ b/test/Serilog.Sinks.Console.Tests/Support/TracingConsoleTheme.cs
@@ -11,9 +11,9 @@ namespace Serilog.Sinks.SystemConsole.Tests
 
         protected override int ResetCharCount { get; } = End.Length;
 
-        public override int Set(TextWriter output, ConsoleThemeStyle style)
+        public override int Set(TextWriter output, ConsoleThemeStyle style, ConsoleThemeStyle levelLineStyle)
         {
-            var start = $"<{style.ToString().ToLowerInvariant()}>";
+            var start = $"<{levelLineStyle.ToString().ToLowerInvariant()} {style.ToString().ToLowerInvariant()}>";
             output.Write(start);
             return start.Length;
         }


### PR DESCRIPTION
**What issue does this PR address?**
#35

**Does this PR introduce a breaking change?**
*Not expected. But please check.*

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog-sinks-console/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)
*Just changes. No extra tests.*

**Other information**:
An example of a possible (if not somewhat ugly) output:
![image](https://user-images.githubusercontent.com/6650122/68421704-08f62b80-019f-11ea-9a3e-d8f3fbc122e1.png)

I'm unsure of line 26 in ThemedValueFormatterState.cs.

Also, there might be a cleaner way to keep the `Events.LogEventLevel.Information` statements out of the tests?

Finally I only implemented `SystemConsoleThemes.Literate` as an example as I have no clue what colouring defaults are appropriate.