### PR TITLE
Added a using statement around the stringwriter.

### DIFF
--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/ConsoleSink.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/ConsoleSink.cs
@@ -58,13 +58,15 @@ namespace Serilog.Sinks.SystemConsole
             // buffered write here and have no effect when the line is actually written out.
             if (_theme.CanBuffer)
             {
-                var buffer = new StringWriter(new StringBuilder(DefaultWriteBufferCapacity));
-                _formatter.Format(logEvent, buffer);
-                var formattedLogEventText = buffer.ToString();
-                lock (_syncRoot)
+                using (var buffer = new StringWriter(new StringBuilder(DefaultWriteBufferCapacity)))
                 {
-                    output.Write(formattedLogEventText);
-                    output.Flush();
+                    _formatter.Format(logEvent, buffer);
+                    var formattedLogEventText = buffer.ToString();
+                    lock (_syncRoot)
+                    {
+                        output.Write(formattedLogEventText);
+                        output.Flush();
+                    }
                 }
             }
             else


### PR DESCRIPTION
**What issue does this PR address?**
A memory leak in the log emit method.

*Please list any GitHub issues here*
https://github.com/serilog/serilog-sinks-console/issues/93

**Does this PR introduce a breaking change?**
No

*Please list any changes that may cause issues for users, including binary breaking changes*
None

**Please check if the PR fulfills these requirements**
- [x ] The commit follows our [guidelines](https://github.com/serilog/serilog-sinks-console/blob/dev/CONTRIBUTING.md)
- [x ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
*Please list any other relevant information here*
