### PR TITLE
Optimization - Use faster null checking

### DIFF
--- a/src/Serilog.Sinks.Console/ConsoleLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Console/ConsoleLoggerConfigurationExtensions.cs
@@ -28,7 +28,7 @@ namespace Serilog
     /// </summary>
     public static class ConsoleLoggerConfigurationExtensions
     {
-        static object DefaultSyncRoot = new object();
+        static readonly object DefaultSyncRoot = new object();
         const string DefaultConsoleOutputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}";
 
         /// <summary>

--- a/src/Serilog.Sinks.Console/ConsoleLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Console/ConsoleLoggerConfigurationExtensions.cs
@@ -61,8 +61,8 @@ namespace Serilog
             bool applyThemeToRedirectedOutput = false,
             object syncRoot = null)
         {
-            if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
-            if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
+            if (sinkConfiguration is null) throw new ArgumentNullException(nameof(sinkConfiguration));
+            if (outputTemplate is null) throw new ArgumentNullException(nameof(outputTemplate));
 
             var appliedTheme = !applyThemeToRedirectedOutput && (System.Console.IsOutputRedirected || System.Console.IsErrorRedirected) ?
                 ConsoleTheme.None :
@@ -97,8 +97,8 @@ namespace Serilog
             LogEventLevel? standardErrorFromLevel = null,
             object syncRoot = null)
         {
-            if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
-            if (formatter == null) throw new ArgumentNullException(nameof(formatter));
+            if (sinkConfiguration is null) throw new ArgumentNullException(nameof(sinkConfiguration));
+            if (formatter is null) throw new ArgumentNullException(nameof(formatter));
 
             syncRoot = syncRoot ?? DefaultSyncRoot;
             return sinkConfiguration.Sink(new ConsoleSink(ConsoleTheme.None, formatter, standardErrorFromLevel, syncRoot), restrictedToMinimumLevel, levelSwitch);

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/ConsoleSink.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/ConsoleSink.cs
@@ -79,7 +79,7 @@ namespace Serilog.Sinks.SystemConsole
 
         TextWriter SelectOutputStream(LogEventLevel logEventLevel)
         {
-            if (_standardErrorFromLevel == null)
+            if (_standardErrorFromLevel is null)
                 return Console.Out;
 
             return logEventLevel < _standardErrorFromLevel ? Console.Out : Console.Error;

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedDisplayValueFormatter.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedDisplayValueFormatter.cs
@@ -37,14 +37,14 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
         protected override int VisitScalarValue(ThemedValueFormatterState state, ScalarValue scalar)
         {
-            if (scalar == null)
+            if (scalar is null)
                 throw new ArgumentNullException(nameof(scalar));
             return FormatLiteralValue(scalar, state.Output, state.Format);
         }
 
         protected override int VisitSequenceValue(ThemedValueFormatterState state, SequenceValue sequence)
         {
-            if (sequence == null)
+            if (sequence is null)
                 throw new ArgumentNullException(nameof(sequence));
 
             var count = 0;
@@ -155,7 +155,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
             var value = scalar.Value;
             var count = 0;
 
-            if (value == null)
+            if (value is null)
             {
                 using (ApplyStyle(output, ConsoleThemeStyle.Null, ref count))
                     output.Write("null");

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedJsonValueFormatter.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Formatting/ThemedJsonValueFormatter.cs
@@ -40,7 +40,7 @@ namespace Serilog.Sinks.SystemConsole.Formatting
 
         protected override int VisitScalarValue(ThemedValueFormatterState state, ScalarValue scalar)
         {
-            if (scalar == null)
+            if (scalar is null)
                 throw new ArgumentNullException(nameof(scalar));
 
             // At the top level, for scalar values, use "display" rendering.

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/ExceptionTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/ExceptionTokenRenderer.cs
@@ -34,7 +34,7 @@ namespace Serilog.Sinks.SystemConsole.Output
         {
             // Padding is never applied by this renderer.
 
-            if (logEvent.Exception == null)
+            if (logEvent.Exception is null)
                 return;
 
             var lines = new StringReader(logEvent.Exception.ToString());

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/LevelOutputFormat.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/LevelOutputFormat.cs
@@ -57,7 +57,7 @@ namespace Serilog.Sinks.SystemConsole.Output
 
         public static string GetLevelMoniker(LogEventLevel value, string format = null)
         {
-            if (format == null || format.Length != 2 && format.Length != 3)
+            if (format is null || format.Length != 2 && format.Length != 3)
                 return Casing.Format(value.ToString(), format);
 
             // Using int.Parse() here requires allocating a string to exclude the first character prefix.

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/MessageTemplateOutputTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/MessageTemplateOutputTokenRenderer.cs
@@ -54,7 +54,7 @@ namespace Serilog.Sinks.SystemConsole.Output
 
         public override void Render(LogEvent logEvent, TextWriter output)
         {
-            if (_token.Alignment == null || !_theme.CanBuffer)
+            if (_token.Alignment is null || !_theme.CanBuffer)
             {
                 _renderer.Render(logEvent.MessageTemplate, logEvent.Properties, output);
                 return;

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/OutputTemplateRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/OutputTemplateRenderer.cs
@@ -29,7 +29,7 @@ namespace Serilog.Sinks.SystemConsole.Output
 
         public OutputTemplateRenderer(ConsoleTheme theme, string outputTemplate, IFormatProvider formatProvider)
         {
-            if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
+            if (outputTemplate is null) throw new ArgumentNullException(nameof(outputTemplate));
             var template = new MessageTemplateParser().Parse(outputTemplate);
 
             var renderers = new List<OutputTemplateTokenRenderer>();
@@ -77,8 +77,8 @@ namespace Serilog.Sinks.SystemConsole.Output
 
         public void Format(LogEvent logEvent, TextWriter output)
         {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-            if (output == null) throw new ArgumentNullException(nameof(output));
+            if (logEvent is null) throw new ArgumentNullException(nameof(logEvent));
+            if (output is null) throw new ArgumentNullException(nameof(output));
 
             foreach (var renderer in _renderers)
                 renderer.Render(logEvent, output);

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/PropertiesTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/PropertiesTokenRenderer.cs
@@ -61,7 +61,7 @@ namespace Serilog.Sinks.SystemConsole.Output
 
             var value = new StructureValue(included);
 
-            if (_token.Alignment == null || !_theme.CanBuffer)
+            if (_token.Alignment is null || !_theme.CanBuffer)
             {
                 _valueFormatter.Format(value, output, null);
                 return;

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/TimestampTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/TimestampTokenRenderer.cs
@@ -43,7 +43,7 @@ namespace Serilog.Sinks.SystemConsole.Output
             var _ = 0;
             using (_theme.Apply(output, ConsoleThemeStyle.SecondaryText, ref _))
             {
-                if (_token.Alignment == null)
+                if (_token.Alignment is null)
                 {
                     sv.Render(output, _token.Format, _formatProvider);
                 }

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Rendering/Padding.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Rendering/Padding.cs
@@ -29,7 +29,7 @@ namespace Serilog.Sinks.SystemConsole.Rendering
         /// <param name="alignment">The alignment settings to apply when rendering <paramref name="value"/>.</param>
         public static void Apply(TextWriter output, string value, Alignment? alignment)
         {
-            if (alignment == null || value.Length >= alignment.Value.Width)
+            if (alignment is null || value.Length >= alignment.Value.Width)
             {
                 output.Write(value);
                 return;

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/AnsiConsoleTheme.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/AnsiConsoleTheme.cs
@@ -49,7 +49,7 @@ namespace Serilog.Sinks.SystemConsole.Themes
         /// <param name="styles">Styles to apply within the theme.</param>
         public AnsiConsoleTheme(IReadOnlyDictionary<ConsoleThemeStyle, string> styles)
         {
-            if (styles == null) throw new ArgumentNullException(nameof(styles));
+            if (styles is null) throw new ArgumentNullException(nameof(styles));
             _styles = styles.ToDictionary(kv => kv.Key, kv => kv.Value);
         }
 

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/SystemConsoleTheme.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/SystemConsoleTheme.cs
@@ -46,7 +46,7 @@ namespace Serilog.Sinks.SystemConsole.Themes
         /// <param name="styles">Styles to apply within the theme.</param>
         public SystemConsoleTheme(IReadOnlyDictionary<ConsoleThemeStyle, SystemConsoleThemeStyle> styles)
         {
-            if (styles == null) throw new ArgumentNullException(nameof(styles));
+            if (styles is null) throw new ArgumentNullException(nameof(styles));
             Styles = styles.ToDictionary(kv => kv.Key, kv => kv.Value);
         }
 


### PR DESCRIPTION
**What issue does this PR address?**
None

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog-sinks-console/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other Information**:
- Micro-optimization: Replace **null** checking to use `is null` to a 'faster' comparison. _(Possible a very insignificant improvement)_ 
- Code Improvement: Add readonly to the static SyncRoot 