### PR TITLE
Clean-up project references

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -1,9 +1,12 @@
-Write-Host "build: Build started"
+Write-Output "build: Build started"
+
+& dotnet --info
+& dotnet --list-sdks
 
 Push-Location $PSScriptRoot
 
 if(Test-Path .\artifacts) {
-    Write-Host "build: Cleaning .\artifacts"
+    Write-Output "build: Cleaning .\artifacts"
 	Remove-Item .\artifacts -Force -Recurse
 }
 
@@ -15,13 +18,13 @@ $suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch
 $commitHash = $(git rev-parse --short HEAD)
 $buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
 
-Write-Host "build: Package version suffix is $suffix"
-Write-Host "build: Build version suffix is $buildSuffix" 
+Write-Output "build: Package version suffix is $suffix"
+Write-Output "build: Build version suffix is $buildSuffix" 
 
 foreach ($src in Get-ChildItem src/*) {
     Push-Location $src
 
-    Write-Host "build: Packaging project in $src"
+    Write-Output "build: Packaging project in $src"
 
     & dotnet build -c Release --version-suffix=$buildSuffix
     if ($suffix) {
@@ -37,7 +40,7 @@ foreach ($src in Get-ChildItem src/*) {
 foreach ($sample in Get-ChildItem sample/*) {
     Push-Location $sample
 
-    Write-Host "build: Testing project in $sample"
+    Write-Output "build: Testing project in $sample"
 
     & dotnet build -c Release --version-suffix=$buildSuffix
     if($LASTEXITCODE -ne 0) { exit 3 }
@@ -48,7 +51,7 @@ foreach ($sample in Get-ChildItem sample/*) {
 foreach ($test in Get-ChildItem test/*.Tests) {
     Push-Location $test
 
-	Write-Host "build: Testing project in $test"
+	Write-Output "build: Testing project in $test"
 
     & dotnet test -c Release
     if($LASTEXITCODE -ne 0) { exit 3 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ version: '{build}'
 skip_tags: true
 image:
   - Visual Studio 2019
-  - Ubuntu
 configuration: Release
 test: off
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2017
+image:
+  - Visual Studio 2019
+  - Ubuntu
 configuration: Release
 test: off
 build_script:

--- a/sample/ConsoleDemo/ConsoleDemo.csproj
+++ b/sample/ConsoleDemo/ConsoleDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net452;net462;net472;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.Console/Serilog.Sinks.Console.csproj
+++ b/src/Serilog.Sinks.Console/Serilog.Sinks.Console.csproj
@@ -4,7 +4,7 @@
     <Description>A Serilog sink that writes log events to the console/terminal.</Description>
     <VersionPrefix>4.0.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3;netstandard2.0;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard2.0;</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Console</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -20,14 +20,10 @@
     <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Don't reference the full NETStandard.Library -->
-    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'netcoreapp2.0' ">true</DisableImplicitFrameworkReferences>
+    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' != 'netstandard2.0' ">true</DisableImplicitFrameworkReferences>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
     <RootNamespace>Serilog</RootNamespace>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'netcoreapp1.1' OR '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <DefineConstants>$(DefineConstants);PINVOKE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' != 'net45' ">

--- a/src/Serilog.Sinks.Console/Serilog.Sinks.Console.csproj
+++ b/src/Serilog.Sinks.Console/Serilog.Sinks.Console.csproj
@@ -26,33 +26,16 @@
     <RootNamespace>Serilog</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'netcoreapp1.1' OR '$(TargetFramework)' == 'netcoreapp2.0' ">
     <DefineConstants>$(DefineConstants);PINVOKE</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <DefineConstants>$(DefineConstants);PINVOKE;RUNTIME_INFORMATION</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net45' ">
+    <DefineConstants>$(DefineConstants);RUNTIME_INFORMATION</DefineConstants>
   </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.8.0" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Console" Version="4.3.0" />
-  </ItemGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <PackageReference Include="System.Console" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-  </ItemGroup>
-  
 
 </Project>

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Platform/WindowsConsole.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Platform/WindowsConsole.cs
@@ -12,16 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if PINVOKE
 using System;
 using System.Runtime.InteropServices;
-#endif
 
 namespace Serilog.Sinks.SystemConsole.Platform
 {
     static class WindowsConsole
     {
-#if PINVOKE
         public static void EnableVirtualTerminalProcessing()
         {
 #if RUNTIME_INFORMATION
@@ -50,10 +47,6 @@ namespace Serilog.Sinks.SystemConsole.Platform
 
         [DllImport("kernel32.dll", SetLastError = true)]
         static extern bool SetConsoleMode(IntPtr handle, uint mode);
-#else
-        public static void EnableVirtualTerminalProcessing()
-        {
-        }
-#endif
+
     }
 }

--- a/test/Serilog.Sinks.Console.Tests/Serilog.Sinks.Console.Tests.csproj
+++ b/test/Serilog.Sinks.Console.Tests/Serilog.Sinks.Console.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net452;net462;net472;net48</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.SystemConsole.Tests</AssemblyName>
     <PackageId>Serilog.Sinks.Console.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -21,10 +21,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.Console.Tests/Serilog.Sinks.Console.Tests.csproj
+++ b/test/Serilog.Sinks.Console.Tests/Serilog.Sinks.Console.Tests.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
**What issue does this PR address?**
None. This is just a cleanup in the project references.

**Does this PR introduce a breaking change?**
Should not.

**Please check if the PR fulfills these requirements**
- [x ] The commit follows our [guidelines](https://github.com/serilog/serilog-sinks-console/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other Information**:
PINVOKE and DllImport should work in netstandard1.3 and above, I don't see any reason to have a Constants for that.
