### PR TITLE
Add two new 16 color ANSI compatible themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ The following built-in themes are available:
  * `ConsoleTheme.None` - no styling
  * `SystemConsoleTheme.Literate` - styled to replicate _Serilog.Sinks.Literate_, using the `System.Console` coloring modes supported on all Windows/.NET targets; **this is the default when no theme is specified**
  * `SystemConsoleTheme.Grayscale` - a theme using only shades of gray, white, and black
- * `AnsiConsoleTheme.Literate` - an ANSI 16-color version of the "literate" theme; we expect to update this to use 256-colors for a more refined look in future
+ * `AnsiConsoleTheme.Literate` - an ANSI 256-color version of the "literate" theme
+ * `AnsiConsoleTheme.Literate16Color` - an ANSI 16-color version of the "literate" theme that works with light backgrounds
  * `AnsiConsoleTheme.Grayscale` - an ANSI 256-color version of the "grayscale" theme
  * `AnsiConsoleTheme.Code` - an ANSI 256-color Visual Studio Code-inspired theme
+ * `AnsiConsoleTheme.Code16Color` - an ANSI 16-color Visual Studio Code-inspired theme that works with light backgrounds
 
  Adding a new theme is straightforward; examples can be found in the [`SystemConsoleThemes`](https://github.com/serilog/serilog-sinks-console/blob/dev/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/SystemConsoleThemes.cs) and [`AnsiConsoleThemes`](https://github.com/serilog/serilog-sinks-console/blob/dev/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/AnsiConsoleThemes.cs) classes.
 

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/AnsiConsoleTheme.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/AnsiConsoleTheme.cs
@@ -31,6 +31,11 @@ namespace Serilog.Sinks.SystemConsole.Themes
         public static AnsiConsoleTheme Code { get; } = AnsiConsoleThemes.Code;
 
         /// <summary>
+        /// A 16-color theme along the lines of Visual Studio Code that should work on light backgrounds.
+        /// </summary>
+        public static AnsiConsoleTheme Code16Color { get; } = AnsiConsoleThemes.Code16Color;
+
+        /// <summary>
         /// A theme using only gray, black and white.
         /// </summary>
         public static AnsiConsoleTheme Grayscale { get; } = AnsiConsoleThemes.Grayscale;
@@ -39,6 +44,11 @@ namespace Serilog.Sinks.SystemConsole.Themes
         /// A theme in the style of the original <i>Serilog.Sinks.Literate</i>.
         /// </summary>
         public static AnsiConsoleTheme Literate { get; } = AnsiConsoleThemes.Literate;
+
+        /// <summary>
+        /// A theme in the style of the original <i>Serilog.Sinks.Literate</i> using only standard 16 terminal colors that will work on light backgrounds.
+        /// </summary>
+        public static AnsiConsoleTheme Literate16Color { get; } = AnsiConsoleThemes.Literate16Color;
 
         readonly IReadOnlyDictionary<ConsoleThemeStyle, string> _styles;
         const string AnsiStyleReset = "\x1b[0m";

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/AnsiConsoleThemes.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Themes/AnsiConsoleThemes.cs
@@ -18,6 +18,27 @@ namespace Serilog.Sinks.SystemConsole.Themes
 {
     static class AnsiConsoleThemes
     {
+        const string Reset = "\x1b[0m";
+        const string Bold = "\x1b[1m";
+
+        const string Black = "\x1b[30m";
+        const string Red = "\x1b[31m";
+        const string Green = "\x1b[32m";
+        const string Yellow = "\x1b[33m";
+        const string Blue = "\x1b[34m";
+        const string Magenta = "\x1b[35m";
+        const string Cyan = "\x1b[36m";
+        const string White = "\x1b[37m";
+
+        const string BrightBlack = "\x1b[30;1m";
+        const string BrightRed = "\x1b[31;1m";
+        const string BrightGreen = "\x1b[32;1m";
+        const string BrightYellow = "\x1b[33;1m";
+        const string BrightBlue = "\x1b[34;1m";
+        const string BrightMagenta = "\x1b[35;1m";
+        const string BrightCyan = "\x1b[36;1m";
+        const string BrightWhite = "\x1b[37;1m";
+
         public static AnsiConsoleTheme Literate { get; } = new AnsiConsoleTheme(
             new Dictionary<ConsoleThemeStyle, string>
             {
@@ -35,6 +56,27 @@ namespace Serilog.Sinks.SystemConsole.Themes
                 [ConsoleThemeStyle.LevelDebug] = "\x1b[38;5;0007m",
                 [ConsoleThemeStyle.LevelInformation] = "\x1b[38;5;0015m",
                 [ConsoleThemeStyle.LevelWarning] = "\x1b[38;5;0011m",
+                [ConsoleThemeStyle.LevelError] = "\x1b[38;5;0015m\x1b[48;5;0196m",
+                [ConsoleThemeStyle.LevelFatal] = "\x1b[38;5;0015m\x1b[48;5;0196m",
+            });
+
+        public static AnsiConsoleTheme Literate16Color { get; } = new AnsiConsoleTheme(
+            new Dictionary<ConsoleThemeStyle, string>
+            {
+                [ConsoleThemeStyle.Text] = Reset,
+                [ConsoleThemeStyle.SecondaryText] = Reset,
+                [ConsoleThemeStyle.TertiaryText] = Reset,
+                [ConsoleThemeStyle.Invalid] = Yellow,
+                [ConsoleThemeStyle.Null] = Blue,
+                [ConsoleThemeStyle.Name] = Reset,
+                [ConsoleThemeStyle.String] = Cyan,
+                [ConsoleThemeStyle.Number] = Magenta,
+                [ConsoleThemeStyle.Boolean] = Blue,
+                [ConsoleThemeStyle.Scalar] = Green,
+                [ConsoleThemeStyle.LevelVerbose] = Reset,
+                [ConsoleThemeStyle.LevelDebug] = Bold,
+                [ConsoleThemeStyle.LevelInformation] = BrightCyan,
+                [ConsoleThemeStyle.LevelWarning] = BrightYellow,
                 [ConsoleThemeStyle.LevelError] = "\x1b[38;5;0015m\x1b[48;5;0196m",
                 [ConsoleThemeStyle.LevelFatal] = "\x1b[38;5;0015m\x1b[48;5;0196m",
             });
@@ -77,6 +119,27 @@ namespace Serilog.Sinks.SystemConsole.Themes
                 [ConsoleThemeStyle.LevelDebug] = "\x1b[37m",
                 [ConsoleThemeStyle.LevelInformation] = "\x1b[37;1m",
                 [ConsoleThemeStyle.LevelWarning] = "\x1b[38;5;0229m",
+                [ConsoleThemeStyle.LevelError] = "\x1b[38;5;0197m\x1b[48;5;0238m",
+                [ConsoleThemeStyle.LevelFatal] = "\x1b[38;5;0197m\x1b[48;5;0238m",
+            });
+
+        public static AnsiConsoleTheme Code16Color { get; } = new AnsiConsoleTheme(
+            new Dictionary<ConsoleThemeStyle, string>
+            {
+                [ConsoleThemeStyle.Text] = Reset,
+                [ConsoleThemeStyle.SecondaryText] = Reset,
+                [ConsoleThemeStyle.TertiaryText] = Reset,
+                [ConsoleThemeStyle.Invalid] = BrightYellow,
+                [ConsoleThemeStyle.Null] = Cyan,
+                [ConsoleThemeStyle.Name] = Cyan,
+                [ConsoleThemeStyle.String] = Yellow,
+                [ConsoleThemeStyle.Number] = BrightYellow,
+                [ConsoleThemeStyle.Boolean] = Cyan,
+                [ConsoleThemeStyle.Scalar] = Green,
+                [ConsoleThemeStyle.LevelVerbose] = Reset,
+                [ConsoleThemeStyle.LevelDebug] = Reset,
+                [ConsoleThemeStyle.LevelInformation] = Bold,
+                [ConsoleThemeStyle.LevelWarning] = BrightYellow,
                 [ConsoleThemeStyle.LevelError] = "\x1b[38;5;0197m\x1b[48;5;0238m",
                 [ConsoleThemeStyle.LevelFatal] = "\x1b[38;5;0197m\x1b[48;5;0238m",
             });


### PR DESCRIPTION
**What issue does this PR address?**
The ANSI themes look great if you're using a black background, I use the Novel theme for my terminals, and the defaults for both Literal and Code themes are impossible to read:
![image](https://user-images.githubusercontent.com/6681/136453738-71638b45-4bbf-4730-ab5e-5a169fb07303.png)
This pull creates two new themes that are compatible with all the default mac terminal themes, mostly by avoiding using black/white colors and using the default more heavily.

Code16Color:
![image](https://user-images.githubusercontent.com/6681/136453824-1aa37c24-61e7-4b1d-a023-6dcb378a3721.png)


**Does this PR introduce a breaking change?**
No breaking changes

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog-sinks-console/blob/dev/CONTRIBUTING.md)
