### PR TITLE
Fix ExceptionTokenRenderer to WriteLine after reset sequence

### DIFF
--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/ExceptionTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/ExceptionTokenRenderer.cs
@@ -44,7 +44,8 @@ namespace Serilog.Sinks.SystemConsole.Output
                 var style = nextLine.StartsWith(StackFrameLinePrefix) ? ConsoleThemeStyle.SecondaryText : ConsoleThemeStyle.Text;
                 var _ = 0;
                 using (_theme.Apply(output, style, ref _))
-                    output.WriteLine(nextLine);
+                    output.Write(nextLine);
+                output.WriteLine();
             }
         }
     }


### PR DESCRIPTION
**What issue does this PR address?**
Fixes #119

**Does this PR introduce a breaking change?**
I rather expect that some things magically start working for some users :)

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog-sinks-console/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
Since there were no breaking tests, I haven't added anything. I figure to properly test this, it would require some more test infrastructure. Hope you're still okay with it.
