### PR TITLE
Fix level casing when length set to 5 and more

### DIFF
--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/LevelOutputFormat.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/LevelOutputFormat.cs
@@ -77,7 +77,14 @@ namespace Serilog.Sinks.SystemConsole.Output
                 var stringValue = value.ToString();
                 if (stringValue.Length > width)
                     stringValue = stringValue.Substring(0, width);
-                return Casing.Format(stringValue);
+                return Casing.Format(stringValue, format is null ? format : FormatByChar(format[0]));
+
+                static string? FormatByChar(char format) => format switch
+                {
+                    'u' => "u",
+                    'w' => "w",
+                    _ => null,
+                };
             }
 
             var index = (int)value;

--- a/test/Serilog.Sinks.Console.Tests/Configuration/ConsoleLoggerConfigurationExtensionsTests.cs
+++ b/test/Serilog.Sinks.Console.Tests/Configuration/ConsoleLoggerConfigurationExtensionsTests.cs
@@ -33,7 +33,7 @@ namespace Serilog.Sinks.Console.Tests.Configuration
                 }
             }
         }
-        
+
         [Fact]
         public void OutputFormattingIsPresent()
         {

--- a/test/Serilog.Sinks.Console.Tests/Output/OutputTemplateRendererTests.cs
+++ b/test/Serilog.Sinks.Console.Tests/Output/OutputTemplateRendererTests.cs
@@ -105,11 +105,23 @@ namespace Serilog.Sinks.Console.Tests.Output
             int width,
             string expected)
         {
-            var formatter = new OutputTemplateRenderer(ConsoleTheme.None, $"{{Level:t{width}}}", CultureInfo.InvariantCulture);
-            var evt = DelegatingSink.GetLogEvent(l => l.Write(level, "Hello"));
-            var sw = new StringWriter();
-            formatter.Format(evt, sw);
-            Assert.Equal(expected, sw.ToString());
+            var formatter1 = new OutputTemplateRenderer(ConsoleTheme.None, $"{{Level:t{width}}}", CultureInfo.InvariantCulture);
+            var evt1 = DelegatingSink.GetLogEvent(l => l.Write(level, "Hello"));
+            var sw1 = new StringWriter();
+            formatter1.Format(evt1, sw1);
+            Assert.Equal(expected, sw1.ToString());
+
+            var formatter2 = new OutputTemplateRenderer(ConsoleTheme.None, $"{{Level:u{width}}}", CultureInfo.InvariantCulture);
+            var evt2 = DelegatingSink.GetLogEvent(l => l.Write(level, "Hello"));
+            var sw2 = new StringWriter();
+            formatter2.Format(evt2, sw2);
+            Assert.Equal(expected.ToUpper(), sw2.ToString());
+
+            var formatter3 = new OutputTemplateRenderer(ConsoleTheme.None, $"{{Level:w{width}}}", CultureInfo.InvariantCulture);
+            var evt3 = DelegatingSink.GetLogEvent(l => l.Write(level, "Hello"));
+            var sw3 = new StringWriter();
+            formatter3.Format(evt3, sw3);
+            Assert.Equal(expected.ToLower(), sw3.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
fixes #76

https://github.com/serilog/serilog-sinks-console/issues/76#issuecomment-553662285 - @nblumhardt yes, fix is rather simple.

Also I would like to note that all that formatting code jumping around strings can be rewritten to allocate less memory. In ideal `GetLevelMoniker` should not allocate at all. It's not hard - just to add additional entries into 3 tables inside `LevelOutputFormat`. I do not know why it was not done before.