### PR TITLE
Update Serilog dependency to 3.1.1

### DIFF
--- a/src/Serilog.Sinks.Console/Serilog.Sinks.Console.csproj
+++ b/src/Serilog.Sinks.Console/Serilog.Sinks.Console.csproj
@@ -39,7 +39,7 @@
     </PropertyGroup>
      
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="3.1.0-*" />
+        <PackageReference Include="Serilog" Version="3.1.1" />
         <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
     </ItemGroup>
     


### PR DESCRIPTION
Ensures installing this package without an additional Serilog dependency does not pull in the broken 3.1.0. See https://github.com/serilog/serilog-sinks-console/issues/148#issuecomment-1830028602.