### PR TITLE
Support UtcTimestamp token in output template (new since Serilog 4.0)

### DIFF
--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/OutputTemplateRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/OutputTemplateRenderer.cs
@@ -68,7 +68,11 @@ class OutputTemplateRenderer : ITextFormatter
                 }
                 else if (pt.PropertyName == OutputProperties.TimestampPropertyName)
                 {
-                    renderers.Add(new TimestampTokenRenderer(theme, pt, formatProvider));
+                    renderers.Add(new TimestampTokenRenderer(theme, pt, formatProvider, convertToUtc: false));
+                }
+                else if (pt.PropertyName == OutputProperties.UtcTimestampPropertyName)
+                {
+                    renderers.Add(new TimestampTokenRenderer(theme, pt, formatProvider, convertToUtc: true));
                 }
                 else if (pt.PropertyName == OutputProperties.PropertiesPropertyName)
                 {

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/TimestampTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/TimestampTokenRenderer.cs
@@ -31,10 +31,10 @@ class TimestampTokenRenderer : OutputTemplateTokenRenderer
 
     public TimestampTokenRenderer(ConsoleTheme theme, PropertyToken token, IFormatProvider? formatProvider, bool convertToUtc)
     {
-            _theme = theme;
-            _token = token;
-            _formatProvider = formatProvider;
-            _convertToUtc = convertToUtc;
+        _theme = theme;
+        _token = token;
+        _formatProvider = formatProvider;
+        _convertToUtc = convertToUtc;
     }
 
     public override void Render(LogEvent logEvent, TextWriter output)
@@ -44,29 +44,29 @@ class TimestampTokenRenderer : OutputTemplateTokenRenderer
             : logEvent.Timestamp;
         var sv = new DateTimeOffsetValue(timestamp);
 
-            var _ = 0;
-            using (_theme.Apply(output, ConsoleThemeStyle.SecondaryText, ref _))
+        var _ = 0;
+        using (_theme.Apply(output, ConsoleThemeStyle.SecondaryText, ref _))
+        {
+            if (_token.Alignment is null)
             {
-                if (_token.Alignment is null)
-                {
-                    sv.Render(output, _token.Format, _formatProvider);
-                }
-                else
-                {
-                    var buffer = new StringWriter();
-                    sv.Render(buffer, _token.Format, _formatProvider);
-                    var str = buffer.ToString();
-                    Padding.Apply(output, str, _token.Alignment);
-                }
+                sv.Render(output, _token.Format, _formatProvider);
+            }
+            else
+            {
+                var buffer = new StringWriter();
+                sv.Render(buffer, _token.Format, _formatProvider);
+                var str = buffer.ToString();
+                Padding.Apply(output, str, _token.Alignment);
             }
         }
+    }
 
     readonly struct DateTimeOffsetValue
     {
         public DateTimeOffsetValue(DateTimeOffset value)
         {
-                Value = value;
-            }
+            Value = value;
+        }
 
         public DateTimeOffset Value { get; }
 
@@ -80,11 +80,11 @@ class TimestampTokenRenderer : OutputTemplateTokenRenderer
             }
 
 #if FEATURE_SPAN
-                Span<char> buffer = stackalloc char[32];
-                if (Value.TryFormat(buffer, out int written, format, formatProvider ?? CultureInfo.InvariantCulture))
-                    output.Write(buffer.Slice(0, written));
-                else
-                    output.Write(Value.ToString(format, formatProvider ?? CultureInfo.InvariantCulture));
+            Span<char> buffer = stackalloc char[32];
+            if (Value.TryFormat(buffer, out int written, format, formatProvider ?? CultureInfo.InvariantCulture))
+                output.Write(buffer.Slice(0, written));
+            else
+                output.Write(Value.ToString(format, formatProvider ?? CultureInfo.InvariantCulture));
 #else
             output.Write(Value.ToString(format, formatProvider ?? CultureInfo.InvariantCulture));
 #endif

--- a/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/TimestampTokenRenderer.cs
+++ b/src/Serilog.Sinks.Console/Sinks/SystemConsole/Output/TimestampTokenRenderer.cs
@@ -27,17 +27,22 @@ class TimestampTokenRenderer : OutputTemplateTokenRenderer
     readonly ConsoleTheme _theme;
     readonly PropertyToken _token;
     readonly IFormatProvider? _formatProvider;
+    readonly bool _convertToUtc;
 
-    public TimestampTokenRenderer(ConsoleTheme theme, PropertyToken token, IFormatProvider? formatProvider)
+    public TimestampTokenRenderer(ConsoleTheme theme, PropertyToken token, IFormatProvider? formatProvider, bool convertToUtc)
     {
             _theme = theme;
             _token = token;
             _formatProvider = formatProvider;
-        }
+            _convertToUtc = convertToUtc;
+    }
 
     public override void Render(LogEvent logEvent, TextWriter output)
     {
-            var sv = new DateTimeOffsetValue(logEvent.Timestamp);
+        var timestamp = _convertToUtc
+            ? logEvent.Timestamp.ToUniversalTime()
+            : logEvent.Timestamp;
+        var sv = new DateTimeOffsetValue(timestamp);
 
             var _ = 0;
             using (_theme.Apply(output, ConsoleThemeStyle.SecondaryText, ref _))

--- a/test/Serilog.Sinks.Console.Tests/Output/OutputTemplateRendererTests.cs
+++ b/test/Serilog.Sinks.Console.Tests/Output/OutputTemplateRendererTests.cs
@@ -401,49 +401,35 @@ public class OutputTemplateRendererTests
         Assert.Equal($"{traceId}/{spanId}", sw.ToString());
     }
 
-    [Fact]
-    public void TimestampTokenRendersLocalTime()
+    [Theory]
+    [InlineData("{Timestamp}", "09/03/2024 14:15:16 +02:00")] // Default Format
+    [InlineData("{Timestamp:o}", "2024-09-03T14:15:16.0790000+02:00")] // Round-trip Standard Format String
+    [InlineData("{Timestamp:yyyy-MM-dd HH:mm:ss}", "2024-09-03 14:15:16")] // Custom Format String
+    public void TimestampTokenRendersLocalTime(string actualToken, string expectedOutput)
     {
         var logTimestampWithTimeZoneOffset = DateTimeOffset.Parse("2024-09-03T14:15:16.079+02:00", CultureInfo.InvariantCulture);
-        var formatter = new OutputTemplateRenderer(ConsoleTheme.None,
-            """
-            Default Format: {Timestamp}
-            Round-trip Standard Format String: {Timestamp:o}
-            Custom Format String: {Timestamp:yyyy-MM-dd HH:mm:ss}
-            """,
-            CultureInfo.InvariantCulture);
+        var formatter = new OutputTemplateRenderer(ConsoleTheme.None, actualToken, CultureInfo.InvariantCulture);
         var evt = new LogEvent(logTimestampWithTimeZoneOffset, LogEventLevel.Debug, null,
             new MessageTemplate(Enumerable.Empty<MessageTemplateToken>()), Enumerable.Empty<LogEventProperty>());
         var sw = new StringWriter();
         formatter.Format(evt, sw);
         // expect time in local time, unchanged from the input, the +02:00 offset should not affect the output
-        Assert.Equal("""
-                     Default Format: 09/03/2024 14:15:16 +02:00
-                     Round-trip Standard Format String: 2024-09-03T14:15:16.0790000+02:00
-                     Custom Format String: 2024-09-03 14:15:16
-                     """, sw.ToString());
+        Assert.Equal(expectedOutput, sw.ToString());
     }
 
-    [Fact]
-    public void UtcTimestampTokenRendersUtcTime()
+    [Theory]
+    [InlineData("{UtcTimestamp}", "09/03/2024 12:15:16")] // Default Format
+    [InlineData("{UtcTimestamp:o}", "2024-09-03T12:15:16.0790000Z")] // Round-trip Standard Format String
+    [InlineData("{UtcTimestamp:yyyy-MM-dd HH:mm:ss}", "2024-09-03 12:15:16")] // Custom Format String
+    public void UtcTimestampTokenRendersUtcTime(string actualToken, string expectedOutput)
     {
         var logTimestampWithTimeZoneOffset = DateTimeOffset.Parse("2024-09-03T14:15:16.079+02:00", CultureInfo.InvariantCulture);
-        var formatter = new OutputTemplateRenderer(ConsoleTheme.None,
-            """
-            Default Format: {UtcTimestamp}
-            Round-trip Standard Format String: {UtcTimestamp:o}
-            Custom Format String: {UtcTimestamp:yyyy-MM-dd HH:mm:ss}
-            """,
-            CultureInfo.InvariantCulture);
+        var formatter = new OutputTemplateRenderer(ConsoleTheme.None, actualToken, CultureInfo.InvariantCulture);
         var evt = new LogEvent(logTimestampWithTimeZoneOffset, LogEventLevel.Debug, null,
             new MessageTemplate(Enumerable.Empty<MessageTemplateToken>()), Enumerable.Empty<LogEventProperty>());
         var sw = new StringWriter();
         formatter.Format(evt, sw);
         // expect time in UTC, the +02:00 offset must be applied to adjust the hour
-        Assert.Equal("""
-                     Default Format: 09/03/2024 12:15:16
-                     Round-trip Standard Format String: 2024-09-03T12:15:16.0790000Z
-                     Custom Format String: 2024-09-03 12:15:16
-                     """, sw.ToString());
+        Assert.Equal(expectedOutput, sw.ToString());
     }
 }

--- a/test/Serilog.Sinks.Console.Tests/Output/OutputTemplateRendererTests.cs
+++ b/test/Serilog.Sinks.Console.Tests/Output/OutputTemplateRendererTests.cs
@@ -400,4 +400,28 @@ public class OutputTemplateRendererTests
         formatter.Format(evt, sw);
         Assert.Equal($"{traceId}/{spanId}", sw.ToString());
     }
+
+    [Fact]
+    public void TimestampTokenRendersLocalTime()
+    {
+        var logTimestampWithTimeZoneOffset = DateTimeOffset.Parse("2024-09-03T14:15:16.079+02:00", CultureInfo.InvariantCulture);
+        var formatter = new OutputTemplateRenderer(ConsoleTheme.None, "{Timestamp:yyyy-MM-dd HH:mm:ss}", CultureInfo.InvariantCulture);
+        var evt = new LogEvent(logTimestampWithTimeZoneOffset, LogEventLevel.Information, null, MessageTemplate.Empty, Array.Empty<LogEventProperty>());
+        var sw = new StringWriter();
+        formatter.Format(evt, sw);
+        // expect time in local time, unchanged from the input, the +02:00 offset should not affect the output
+        Assert.Equal("2024-09-03 14:15:16", sw.ToString());
+    }
+
+    [Fact]
+    public void UtcTimestampTokenRendersUtcTime()
+    {
+        var logTimestampWithTimeZoneOffset = DateTimeOffset.Parse("2024-09-03T14:15:16.079+02:00", CultureInfo.InvariantCulture);
+        var formatter = new OutputTemplateRenderer(ConsoleTheme.None, "{UtcTimestamp:yyyy-MM-dd HH:mm:ss}", CultureInfo.InvariantCulture);
+        var evt = new LogEvent(logTimestampWithTimeZoneOffset, LogEventLevel.Information, null, MessageTemplate.Empty, Array.Empty<LogEventProperty>());
+        var sw = new StringWriter();
+        formatter.Format(evt, sw);
+        // expect time in UTC, the +02:00 offset must be applied to adjust the hour
+        Assert.Equal("2024-09-03 12:15:16", sw.ToString());
+    }
 }

--- a/test/Serilog.Sinks.Console.Tests/Output/OutputTemplateRendererTests.cs
+++ b/test/Serilog.Sinks.Console.Tests/Output/OutputTemplateRendererTests.cs
@@ -405,25 +405,29 @@ public class OutputTemplateRendererTests
     public void TimestampTokenRendersLocalTime()
     {
         var logTimestampWithTimeZoneOffset = DateTimeOffset.Parse("2024-09-03T14:15:16.079+02:00", CultureInfo.InvariantCulture);
-        var formatter = new OutputTemplateRenderer(ConsoleTheme.None, "{Timestamp:yyyy-MM-dd HH:mm:ss}", CultureInfo.InvariantCulture);
+        var formatter = new OutputTemplateRenderer(ConsoleTheme.None,
+            "Default Format: {Timestamp} / Custom Format String: {Timestamp:yyyy-MM-dd HH:mm:ss}",
+            CultureInfo.InvariantCulture);
         var evt = new LogEvent(logTimestampWithTimeZoneOffset, LogEventLevel.Debug, null,
             new MessageTemplate(Enumerable.Empty<MessageTemplateToken>()), Enumerable.Empty<LogEventProperty>());
         var sw = new StringWriter();
         formatter.Format(evt, sw);
         // expect time in local time, unchanged from the input, the +02:00 offset should not affect the output
-        Assert.Equal("2024-09-03 14:15:16", sw.ToString());
+        Assert.Equal("Default Format: 09/03/2024 14:15:16 +02:00 / Custom Format String: 2024-09-03 14:15:16", sw.ToString());
     }
 
     [Fact]
     public void UtcTimestampTokenRendersUtcTime()
     {
         var logTimestampWithTimeZoneOffset = DateTimeOffset.Parse("2024-09-03T14:15:16.079+02:00", CultureInfo.InvariantCulture);
-        var formatter = new OutputTemplateRenderer(ConsoleTheme.None, "{UtcTimestamp:yyyy-MM-dd HH:mm:ss}", CultureInfo.InvariantCulture);
+        var formatter = new OutputTemplateRenderer(ConsoleTheme.None,
+            "Default Format: {UtcTimestamp} / Custom Format String: {UtcTimestamp:yyyy-MM-dd HH:mm:ss}",
+            CultureInfo.InvariantCulture);
         var evt = new LogEvent(logTimestampWithTimeZoneOffset, LogEventLevel.Debug, null,
             new MessageTemplate(Enumerable.Empty<MessageTemplateToken>()), Enumerable.Empty<LogEventProperty>());
         var sw = new StringWriter();
         formatter.Format(evt, sw);
         // expect time in UTC, the +02:00 offset must be applied to adjust the hour
-        Assert.Equal("2024-09-03 12:15:16", sw.ToString());
+        Assert.Equal("Default Format: 09/03/2024 12:15:16 / Custom Format String: 2024-09-03 12:15:16", sw.ToString());
     }
 }

--- a/test/Serilog.Sinks.Console.Tests/Output/OutputTemplateRendererTests.cs
+++ b/test/Serilog.Sinks.Console.Tests/Output/OutputTemplateRendererTests.cs
@@ -406,14 +406,22 @@ public class OutputTemplateRendererTests
     {
         var logTimestampWithTimeZoneOffset = DateTimeOffset.Parse("2024-09-03T14:15:16.079+02:00", CultureInfo.InvariantCulture);
         var formatter = new OutputTemplateRenderer(ConsoleTheme.None,
-            "Default Format: {Timestamp} / Custom Format String: {Timestamp:yyyy-MM-dd HH:mm:ss}",
+            """
+            Default Format: {Timestamp}
+            Round-trip Standard Format String: {Timestamp:o}
+            Custom Format String: {Timestamp:yyyy-MM-dd HH:mm:ss}
+            """,
             CultureInfo.InvariantCulture);
         var evt = new LogEvent(logTimestampWithTimeZoneOffset, LogEventLevel.Debug, null,
             new MessageTemplate(Enumerable.Empty<MessageTemplateToken>()), Enumerable.Empty<LogEventProperty>());
         var sw = new StringWriter();
         formatter.Format(evt, sw);
         // expect time in local time, unchanged from the input, the +02:00 offset should not affect the output
-        Assert.Equal("Default Format: 09/03/2024 14:15:16 +02:00 / Custom Format String: 2024-09-03 14:15:16", sw.ToString());
+        Assert.Equal("""
+                     Default Format: 09/03/2024 14:15:16 +02:00
+                     Round-trip Standard Format String: 2024-09-03T14:15:16.0790000+02:00
+                     Custom Format String: 2024-09-03 14:15:16
+                     """, sw.ToString());
     }
 
     [Fact]
@@ -421,13 +429,21 @@ public class OutputTemplateRendererTests
     {
         var logTimestampWithTimeZoneOffset = DateTimeOffset.Parse("2024-09-03T14:15:16.079+02:00", CultureInfo.InvariantCulture);
         var formatter = new OutputTemplateRenderer(ConsoleTheme.None,
-            "Default Format: {UtcTimestamp} / Custom Format String: {UtcTimestamp:yyyy-MM-dd HH:mm:ss}",
+            """
+            Default Format: {UtcTimestamp}
+            Round-trip Standard Format String: {UtcTimestamp:o}
+            Custom Format String: {UtcTimestamp:yyyy-MM-dd HH:mm:ss}
+            """,
             CultureInfo.InvariantCulture);
         var evt = new LogEvent(logTimestampWithTimeZoneOffset, LogEventLevel.Debug, null,
             new MessageTemplate(Enumerable.Empty<MessageTemplateToken>()), Enumerable.Empty<LogEventProperty>());
         var sw = new StringWriter();
         formatter.Format(evt, sw);
         // expect time in UTC, the +02:00 offset must be applied to adjust the hour
-        Assert.Equal("Default Format: 09/03/2024 12:15:16 / Custom Format String: 2024-09-03 12:15:16", sw.ToString());
+        Assert.Equal("""
+                     Default Format: 09/03/2024 12:15:16
+                     Round-trip Standard Format String: 2024-09-03T12:15:16.0790000Z
+                     Custom Format String: 2024-09-03 12:15:16
+                     """, sw.ToString());
     }
 }

--- a/test/Serilog.Sinks.Console.Tests/Output/OutputTemplateRendererTests.cs
+++ b/test/Serilog.Sinks.Console.Tests/Output/OutputTemplateRendererTests.cs
@@ -406,7 +406,8 @@ public class OutputTemplateRendererTests
     {
         var logTimestampWithTimeZoneOffset = DateTimeOffset.Parse("2024-09-03T14:15:16.079+02:00", CultureInfo.InvariantCulture);
         var formatter = new OutputTemplateRenderer(ConsoleTheme.None, "{Timestamp:yyyy-MM-dd HH:mm:ss}", CultureInfo.InvariantCulture);
-        var evt = new LogEvent(logTimestampWithTimeZoneOffset, LogEventLevel.Information, null, MessageTemplate.Empty, Array.Empty<LogEventProperty>());
+        var evt = new LogEvent(logTimestampWithTimeZoneOffset, LogEventLevel.Debug, null,
+            new MessageTemplate(Enumerable.Empty<MessageTemplateToken>()), Enumerable.Empty<LogEventProperty>());
         var sw = new StringWriter();
         formatter.Format(evt, sw);
         // expect time in local time, unchanged from the input, the +02:00 offset should not affect the output
@@ -418,7 +419,8 @@ public class OutputTemplateRendererTests
     {
         var logTimestampWithTimeZoneOffset = DateTimeOffset.Parse("2024-09-03T14:15:16.079+02:00", CultureInfo.InvariantCulture);
         var formatter = new OutputTemplateRenderer(ConsoleTheme.None, "{UtcTimestamp:yyyy-MM-dd HH:mm:ss}", CultureInfo.InvariantCulture);
-        var evt = new LogEvent(logTimestampWithTimeZoneOffset, LogEventLevel.Information, null, MessageTemplate.Empty, Array.Empty<LogEventProperty>());
+        var evt = new LogEvent(logTimestampWithTimeZoneOffset, LogEventLevel.Debug, null,
+            new MessageTemplate(Enumerable.Empty<MessageTemplateToken>()), Enumerable.Empty<LogEventProperty>());
         var sw = new StringWriter();
         formatter.Format(evt, sw);
         // expect time in UTC, the +02:00 offset must be applied to adjust the hour


### PR DESCRIPTION
**What issue does this PR address?**
Addresses #164 Support for Serilog 4.0 new built-in UtcTimestamp token in output template was missing in console sink.

**Does this PR introduce a breaking change?**
Recognize UtcTimestamp as a built-in token in output templates. May impact scenarios where UtcTimestamp was present as a user defined property. Same effect as in serilog/serilog#2051.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/serilog/serilog-sinks-console/blob/dev/CONTRIBUTING.md)
- [X] Unit Tests for the changes have been added (for bug fixes / features)
